### PR TITLE
Refactor/add product image

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/media/upload/DefaultUploadProductImageUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/media/upload/DefaultUploadProductImageUseCase.java
@@ -5,7 +5,6 @@ import com.kaua.ecommerce.application.gateways.ProductGateway;
 import com.kaua.ecommerce.domain.exceptions.DomainException;
 import com.kaua.ecommerce.domain.exceptions.NotFoundException;
 import com.kaua.ecommerce.domain.product.Product;
-import com.kaua.ecommerce.domain.product.ProductImageType;
 import com.kaua.ecommerce.domain.validation.Error;
 
 import java.util.Objects;
@@ -32,14 +31,8 @@ public class DefaultUploadProductImageUseCase extends UploadProductImageUseCase 
 
         switch (aResource.type()) {
             case COVER -> {
-                aProduct.getImages()
-                        .forEach(image -> {
-                            if (image.location().contains(ProductImageType.COVER.name())) {
-                                this.mediaResourceGateway.clearImage(image);
-                            }
-                        });
-                aProduct.removeCoverImage();
-                aProduct.addImage(this.mediaResourceGateway.storeImage(aProductId, aResource));
+                aProduct.getCoverImage().ifPresent(this.mediaResourceGateway::clearImage);
+                aProduct.changeCoverImage(this.mediaResourceGateway.storeImage(aProductId, aResource));
             }
             case GALLERY -> aProduct.addImage(this.mediaResourceGateway.storeImage(aProductId, aResource));
             default -> throw DomainException.with(new Error("'productImageType' not implemented"));

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageUseCaseTest.java
@@ -37,7 +37,7 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
         final var aProductImage = Fixture.Products.imageCoverType();
         final var aProduct = Fixture.Products.tshirt();
         final var aProductImageResource = Fixture.Products.imageCoverTypeResource();
-        aProduct.addImage(ProductImage.with(
+        aProduct.changeCoverImage(ProductImage.with(
                 "image.png",
                 "COVER-image.png",
                 "http://localhost:8080/COVER-image.png"
@@ -64,21 +64,15 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
         Mockito.verify(mediaResourceGateway, Mockito.times(1)).storeImage(aProduct.getId(), aProductImageResource);
         Mockito.verify(productGateway, Mockito.times(1)).update(argThat(aCmd ->
                 Objects.equals(aProductId, aCmd.getId().getValue())
-                        && Objects.equals(1, aCmd.getImages().size())
-                        && Objects.equals(aProductImage.id(), aCmd.getImages().stream().findFirst().get().id())
-                        && Objects.equals(aProductImage.location(), aCmd.getImages().stream().findFirst().get().location())));
+                        && Objects.equals(aProductImage.id(), aCmd.getCoverImage().get().id())
+                        && Objects.equals(aProductImage.location(), aCmd.getCoverImage().get().location())));
     }
 
     @Test
-    void givenAValidParamsWithCoverType_whenCallExecuteWithProductContainsGalleryImage_shouldUploadProductImage() {
+    void givenAValidParamsWithCoverType_whenCallExecuteWithProductNotContainsCoverImage_shouldUploadProductImage() {
         final var aProductImage = Fixture.Products.imageCoverType();
         final var aProduct = Fixture.Products.tshirt();
         final var aProductImageResource = Fixture.Products.imageCoverTypeResource();
-        aProduct.addImage(ProductImage.with(
-                "image.png",
-                "GALLERY-image.png",
-                "http://localhost:8080/COVER-image.png"
-        ));
 
         final var aProductId = aProduct.getId().getValue();
 
@@ -100,7 +94,8 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
         Mockito.verify(mediaResourceGateway, Mockito.times(1)).storeImage(aProduct.getId(), aProductImageResource);
         Mockito.verify(productGateway, Mockito.times(1)).update(argThat(aCmd ->
                 Objects.equals(aProductId, aCmd.getId().getValue())
-                        && Objects.equals(2, aCmd.getImages().size())));
+                        && Objects.equals(aProductImage.id(), aCmd.getCoverImage().get().id())
+                        && Objects.equals(aProductImage.location(), aCmd.getCoverImage().get().location())));
     }
 
     @Test

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/Product.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/Product.java
@@ -2,7 +2,9 @@ package com.kaua.ecommerce.domain.product;
 
 import com.kaua.ecommerce.domain.AggregateRoot;
 import com.kaua.ecommerce.domain.category.CategoryID;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
 import com.kaua.ecommerce.domain.utils.InstantUtils;
+import com.kaua.ecommerce.domain.validation.Error;
 import com.kaua.ecommerce.domain.validation.ValidationHandler;
 
 import java.math.BigDecimal;
@@ -116,9 +118,15 @@ public class Product extends AggregateRoot<ProductID> {
     }
 
     public void addImage(final ProductImage aImage) {
-        if (aImage != null) {
-            this.images.add(aImage);
+        if (aImage == null) {
+            return;
         }
+
+        if (this.images.size() == 20) {
+            throw DomainException.with(new Error("Product can't have more than 20 images"));
+        }
+
+        this.images.add(aImage);
     }
 
     public void removeCoverImage() {

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/Product.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/Product.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 public class Product extends AggregateRoot<ProductID> {
@@ -19,6 +20,7 @@ public class Product extends AggregateRoot<ProductID> {
     private String description;
     private BigDecimal price;
     private int quantity;
+    private ProductImage coverImage;
     private Set<ProductImage> images;
     private CategoryID categoryId;
     private Set<ProductAttributes> attributes;
@@ -31,6 +33,7 @@ public class Product extends AggregateRoot<ProductID> {
             final String aDescription,
             final BigDecimal aPrice,
             final int aQuantity,
+            final ProductImage aCoverImage,
             final Set<ProductImage> aImages,
             final CategoryID aCategoryId,
             final Set<ProductAttributes> aAttributes,
@@ -42,6 +45,7 @@ public class Product extends AggregateRoot<ProductID> {
         this.description = aDescription;
         this.price = aPrice;
         this.quantity = aQuantity;
+        this.coverImage = aCoverImage;
         this.images = aImages;
         this.categoryId = aCategoryId;
         this.attributes = aAttributes;
@@ -65,6 +69,7 @@ public class Product extends AggregateRoot<ProductID> {
                 aDescription,
                 aPrice,
                 aQuantity,
+                null,
                 new HashSet<>(),
                 aCategoryId,
                 new HashSet<>(),
@@ -82,6 +87,7 @@ public class Product extends AggregateRoot<ProductID> {
             final String aDescription,
             final BigDecimal aPrice,
             final int aQuantity,
+            final ProductImage aCoverImage,
             final Set<ProductImage> aImages,
             final String aCategoryId,
             final Set<ProductAttributes> aAttributes,
@@ -94,6 +100,7 @@ public class Product extends AggregateRoot<ProductID> {
                 aDescription,
                 aPrice,
                 aQuantity,
+                aCoverImage,
                 new HashSet<>(aImages == null ? Collections.emptySet() : aImages),
                 CategoryID.from(aCategoryId),
                 new HashSet<>(aAttributes == null ? Collections.emptySet() : aAttributes),
@@ -109,6 +116,7 @@ public class Product extends AggregateRoot<ProductID> {
                 aProduct.getDescription(),
                 aProduct.getPrice(),
                 aProduct.getQuantity(),
+                aProduct.getCoverImage().orElse(null),
                 new HashSet<>(aProduct.getImages()),
                 aProduct.getCategoryId(),
                 new HashSet<>(aProduct.getAttributes()),
@@ -129,8 +137,8 @@ public class Product extends AggregateRoot<ProductID> {
         this.images.add(aImage);
     }
 
-    public void removeCoverImage() {
-        this.images.removeIf(aImage -> aImage.location().contains(ProductImageType.COVER.name()));
+    public void changeCoverImage(final ProductImage aImage) {
+        this.coverImage = aImage;
     }
 
     @Override
@@ -152,6 +160,10 @@ public class Product extends AggregateRoot<ProductID> {
 
     public int getQuantity() {
         return quantity;
+    }
+
+    public Optional<ProductImage> getCoverImage() {
+        return Optional.ofNullable(coverImage);
     }
 
     public Set<ProductImage> getImages() {

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductTest.java
@@ -35,6 +35,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aDescription, aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
+        Assertions.assertTrue(aProduct.getCoverImage().isEmpty());
         Assertions.assertTrue(aProduct.getImages().isEmpty());
         Assertions.assertEquals(aCategoryId, aProduct.getCategoryId());
         Assertions.assertEquals(aAttributes, aProduct.getAttributes().stream().findFirst().get());
@@ -63,6 +64,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertNull(aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
+        Assertions.assertTrue(aProduct.getCoverImage().isEmpty());
         Assertions.assertTrue(aProduct.getImages().isEmpty());
         Assertions.assertEquals(aCategoryId, aProduct.getCategoryId());
         Assertions.assertEquals(aAttributes, aProduct.getAttributes().stream().findFirst().get());
@@ -90,6 +92,7 @@ public class ProductTest extends UnitTest {
         final var aDescription = "Product Description";
         final var aPrice = BigDecimal.valueOf(10.0);
         final var aQuantity = 10;
+        final var aCoverImage = ProductImage.with("abc", "cover-product.jpg", "/images/cover-product.jpg");
         final var aImage = ProductImage.with("abc", "product.jpg", "/images/product.jpg");
         final var aCategoryId = CategoryID.from("1");
         final var aAttributes = ProductAttributes.with(
@@ -106,6 +109,7 @@ public class ProductTest extends UnitTest {
                 aDescription,
                 aPrice,
                 aQuantity,
+                aCoverImage,
                 Set.of(aImage),
                 aCategoryId.getValue(),
                 Set.of(aAttributes),
@@ -118,6 +122,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aDescription, aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
+        Assertions.assertEquals(aCoverImage.location(), aProduct.getCoverImage().get().location());
         Assertions.assertEquals(aImage.location(), aProduct.getImages().stream().findFirst().get().location());
         Assertions.assertEquals(aCategoryId.getValue(), aProduct.getCategoryId().getValue());
         Assertions.assertEquals(aAttributes, aProduct.getAttributes().stream().findFirst().get());
@@ -136,6 +141,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aProductWith.getDescription(), aProduct.getDescription());
         Assertions.assertEquals(aProductWith.getPrice(), aProduct.getPrice());
         Assertions.assertEquals(aProductWith.getQuantity(), aProduct.getQuantity());
+        Assertions.assertTrue(aProductWith.getCoverImage().isEmpty());
         Assertions.assertTrue(aProductWith.getImages().isEmpty());
         Assertions.assertEquals(aProductWith.getCategoryId().getValue(), aProduct.getCategoryId().getValue());
         Assertions.assertEquals(aProductWith.getAttributes(), aProduct.getAttributes());
@@ -150,6 +156,7 @@ public class ProductTest extends UnitTest {
         final var aDescription = "Product Description";
         final var aPrice = BigDecimal.valueOf(10.0);
         final var aQuantity = 10;
+        final var aCoverImage = ProductImage.with("abc", "cover-product.jpg", "/images/cover-product.jpg");
         final var aImage = ProductImage.with("abc", "product.jpg", "/images/product.jpg");
         final var aCategoryId = CategoryID.from("1");
         final Set<ProductAttributes> aAttributes = null;
@@ -162,6 +169,7 @@ public class ProductTest extends UnitTest {
                 aDescription,
                 aPrice,
                 aQuantity,
+                aCoverImage,
                 Set.of(aImage),
                 aCategoryId.getValue(),
                 aAttributes,
@@ -174,6 +182,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aDescription, aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
+        Assertions.assertEquals(aCoverImage.location(), aProduct.getCoverImage().get().location());
         Assertions.assertEquals(aImage.id(), aProduct.getImages().stream().findFirst().get().id());
         Assertions.assertEquals(aCategoryId.getValue(), aProduct.getCategoryId().getValue());
         Assertions.assertTrue(aProduct.getAttributes().isEmpty());
@@ -189,6 +198,7 @@ public class ProductTest extends UnitTest {
         final var aPrice = BigDecimal.valueOf(10.0);
         final var aQuantity = 10;
         final var aCategoryId = CategoryID.from("1");
+        final ProductImage aCoverImage = null;
         final Set<ProductImage> aImages = null;
         final var aAttributes = ProductAttributes.with(
                 ProductColor.with("1", "RED"),
@@ -204,6 +214,7 @@ public class ProductTest extends UnitTest {
                 aDescription,
                 aPrice,
                 aQuantity,
+                aCoverImage,
                 aImages,
                 aCategoryId.getValue(),
                 Set.of(aAttributes),
@@ -216,6 +227,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aDescription, aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
+        Assertions.assertTrue(aProduct.getCoverImage().isEmpty());
         Assertions.assertTrue(aProduct.getImages().isEmpty());
         Assertions.assertEquals(aCategoryId.getValue(), aProduct.getCategoryId().getValue());
         Assertions.assertEquals(aAttributes.sku(), aProduct.getAttributes().stream().findFirst().get().sku());
@@ -243,7 +255,7 @@ public class ProductTest extends UnitTest {
     }
 
     @Test
-    void givenAValidImage_whenCallRemoveCoverImage_shouldRemoveImage() {
+    void givenAValidImage_whenCallChangeCoverImage_shouldChangeCoverImage() {
         final var aProduct = Fixture.Products.tshirt();
         final var aProductImageId = IdUtils.generate().replace("-", "");
         final var aLocation = aProduct.getId().getValue() +
@@ -255,11 +267,10 @@ public class ProductTest extends UnitTest {
                 "product.jpg";
         final var aUrl = "http://localhost:8080/images/product.jpg";
         final var aImage = ProductImage.with("abc", "product.jpg", aLocation, aUrl);
-        aProduct.addImage(aImage);
 
-        aProduct.removeCoverImage();
+        aProduct.changeCoverImage(aImage);
 
-        Assertions.assertTrue(aProduct.getImages().isEmpty());
+        Assertions.assertEquals(aImage, aProduct.getCoverImage().get());
     }
 
     @Test

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductTest.java
@@ -3,6 +3,7 @@ package com.kaua.ecommerce.domain.product;
 import com.kaua.ecommerce.domain.Fixture;
 import com.kaua.ecommerce.domain.UnitTest;
 import com.kaua.ecommerce.domain.category.CategoryID;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
 import com.kaua.ecommerce.domain.utils.IdUtils;
 import com.kaua.ecommerce.domain.utils.InstantUtils;
 import com.kaua.ecommerce.domain.validation.handler.ThrowsValidationHandler;
@@ -277,5 +278,25 @@ public class ProductTest extends UnitTest {
         final var aProductImageTypeOf = ProductImageType.of(aProductImageType);
 
         Assertions.assertTrue(aProductImageTypeOf.isEmpty());
+    }
+
+    @Test
+    void givenAnInvalidProductImage_whenCallAddImageWithProductContains20Images_shouldThrowDomainException() {
+        final var aProduct = Fixture.Products.tshirt();
+        final var aImage = ProductImage.with("abc", "product.jpg", "/images/product.jpg");
+
+        for (int i = 0; i < 20; i++) {
+            final var aOldImages = ProductImage.with(
+                    "abc".concat("-").concat(String.valueOf(i)),
+                    "product.jpg".concat("-").concat(String.valueOf(i)),
+                    "/images/product.jpg".concat("-").concat(String.valueOf(i)));
+            aProduct.addImage(aOldImages);
+        }
+
+        Assertions.assertThrows(
+                DomainException.class,
+                () -> aProduct.addImage(aImage),
+                "Product can't have more than 20 images"
+        );
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductMediaResourceGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductMediaResourceGateway.java
@@ -40,6 +40,7 @@ public class ProductMediaResourceGateway implements MediaResourceGateway {
     private ProductImage generateProductImage(ProductID aProductID, ProductImageResource aResource) {
         final var aImageResource = aResource.resource();
         final var aProductImageId = IdUtils.generate().replace("-", "");
+        // TODO: Refactor buildLocation to receive aProductImageId as parameter, in this moment buildLocation use other random id
         final var aLocation = buildLocation(aProductID, aResource);
         final var aUrl = getProviderUrl().concat("/").concat(aLocation);
         return ProductImage.with(

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductJpaEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -34,6 +35,10 @@ public class ProductJpaEntity {
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Set<ProductAttributesJpaEntity> attributes;
 
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "cover_image_id", referencedColumnName = "id")
+    private ProductImageJpaEntity coverImage;
+
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Set<ProductImageRelationJpaEntity> images;
 
@@ -52,6 +57,7 @@ public class ProductJpaEntity {
             final BigDecimal price,
             final int quantity,
             final String categoryId,
+            final ProductImageJpaEntity coverImage,
             final Instant createdAt,
             final Instant updatedAt
     ) {
@@ -62,6 +68,7 @@ public class ProductJpaEntity {
         this.quantity = quantity;
         this.categoryId = categoryId;
         this.attributes = new HashSet<>();
+        this.coverImage = coverImage;
         this.images = new HashSet<>();
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -75,6 +82,7 @@ public class ProductJpaEntity {
                 aProduct.getPrice(),
                 aProduct.getQuantity(),
                 aProduct.getCategoryId().getValue(),
+                aProduct.getCoverImage().map(ProductImageJpaEntity::toEntity).orElse(null),
                 aProduct.getCreatedAt(),
                 aProduct.getUpdatedAt()
         );
@@ -92,6 +100,7 @@ public class ProductJpaEntity {
                 getDescription(),
                 getPrice(),
                 getQuantity(),
+                getCoverImage().map(ProductImageJpaEntity::toDomain).orElse(null),
                 getImagesToDomain(),
                 getCategoryId(),
                 getAttributesToDomain(),
@@ -188,6 +197,14 @@ public class ProductJpaEntity {
 
     public void setAttributes(Set<ProductAttributesJpaEntity> attributes) {
         this.attributes = attributes;
+    }
+
+    public Optional<ProductImageJpaEntity> getCoverImage() {
+        return Optional.ofNullable(coverImage);
+    }
+
+    public void setCoverImage(ProductImageJpaEntity coverImage) {
+        this.coverImage = coverImage;
     }
 
     public Set<ProductImageRelationJpaEntity> getImages() {

--- a/infrastructure/src/main/resources/db/migration/U5__CREATE_PRODUCTS_TABLE.sql
+++ b/infrastructure/src/main/resources/db/migration/U5__CREATE_PRODUCTS_TABLE.sql
@@ -1,6 +1,6 @@
-DROP TABLE products_images_relations;
-DROP TABLE products_images;
 DROP TABLE products_attributes;
 DROP TABLE products_sizes;
 DROP TABLE products_colors;
 DROP TABLE products;
+DROP TABLE products_images_relations;
+DROP TABLE products_images;

--- a/infrastructure/src/main/resources/db/migration/V5__CREATE_PRODUCTS_TABLE.sql
+++ b/infrastructure/src/main/resources/db/migration/V5__CREATE_PRODUCTS_TABLE.sql
@@ -5,6 +5,7 @@ CREATE TABLE products (
     price NUMERIC(19, 2) NOT NULL,
     quantity integer NOT NULL,
     category_id VARCHAR(36) NOT NULL,
+    cover_image_id VARCHAR(36),
     created_at DATETIME(6) NOT NULL,
     updated_at DATETIME(6) NOT NULL
 );

--- a/infrastructure/src/main/resources/db/migration/V5__CREATE_PRODUCTS_TABLE.sql
+++ b/infrastructure/src/main/resources/db/migration/V5__CREATE_PRODUCTS_TABLE.sql
@@ -1,3 +1,10 @@
+CREATE TABLE products_images (
+    id VARCHAR(36) PRIMARY KEY NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    location VARCHAR(255) NOT NULL,
+    url VARCHAR(255) NOT NULL
+);
+
 CREATE TABLE products (
     id VARCHAR(36) PRIMARY KEY NOT NULL,
     name VARCHAR(255) NOT NULL,
@@ -7,7 +14,8 @@ CREATE TABLE products (
     category_id VARCHAR(36) NOT NULL,
     cover_image_id VARCHAR(36),
     created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL
+    updated_at DATETIME(6) NOT NULL,
+    FOREIGN KEY (cover_image_id) REFERENCES products_images(id)
 );
 
 CREATE TABLE products_colors (
@@ -34,12 +42,6 @@ CREATE TABLE products_attributes (
     FOREIGN KEY (size_id) REFERENCES products_sizes(id)
 );
 
-CREATE TABLE products_images (
-    id VARCHAR(36) PRIMARY KEY NOT NULL,
-    name VARCHAR(255) NOT NULL,
-    location VARCHAR(255) NOT NULL,
-    url VARCHAR(255) NOT NULL
-);
 
 CREATE TABLE products_images_relations (
     product_id VARCHAR(36) NOT NULL,

--- a/infrastructure/src/test/java/com/kaua/ecommerce/application/product/media/upload/UploadProductImageUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/application/product/media/upload/UploadProductImageUseCaseIT.java
@@ -44,7 +44,7 @@ public class UploadProductImageUseCaseIT {
 
         final var aProductEntity = this.productJpaRepository.findById(aProductId).get();
 
-        Assertions.assertEquals(1, aProductEntity.getImages().size());
+        Assertions.assertTrue(aProductEntity.getCoverImage().isPresent());
     }
 
     @Test
@@ -72,33 +72,5 @@ public class UploadProductImageUseCaseIT {
         final var aProductEntity = this.productJpaRepository.findById(aProductId).get();
 
         Assertions.assertEquals(1, aProductEntity.getImages().size());
-    }
-
-    @Test
-    void givenAValidValuesWithCoverType_whenCallsUploadProductImage_shouldUploadImageAndReturnProductWithTwoImages() {
-        // given
-        final var aProduct = Fixture.Products.tshirt();
-        final var aProductId = aProduct.getId().getValue();
-        aProduct.addImage(Fixture.Products.imageGalleryType());
-
-        this.productJpaRepository.save(ProductJpaEntity.toEntity(aProduct));
-
-        Assertions.assertEquals(1, this.productJpaRepository.count());
-
-        final var aCommand = UploadProductImageCommand.with(
-                aProductId,
-                Fixture.Products.imageCoverTypeResource()
-        );
-
-        // when
-        final var actualResult = this.uploadProductImageUseCase.execute(aCommand);
-
-        // then
-        Assertions.assertEquals(aProductId, actualResult.productId());
-        Assertions.assertEquals(ProductImageType.COVER.name(), actualResult.productImageType().name());
-
-        final var aProductEntity = this.productJpaRepository.findById(aProductId).get();
-
-        Assertions.assertEquals(2, aProductEntity.getImages().size());
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductJpaRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductJpaRepositoryTest.java
@@ -383,4 +383,37 @@ public class ProductJpaRepositoryTest {
         Assertions.assertEquals(aEntity.getCreatedAt(), actualResult.getCreatedAt());
         Assertions.assertEquals(aEntity.getUpdatedAt(), actualResult.getUpdatedAt());
     }
+
+    @Test
+    void givenAValidNullCoverImage_whenCallSave_shouldReturnProduct() {
+        final var aProduct = Product.newProduct(
+                "Product Name",
+                "Product Description",
+                BigDecimal.valueOf(10.0),
+                10,
+                CategoryID.unique(),
+                ProductAttributes.create(
+                        ProductColor.with("1", "Red"),
+                        ProductSize.with("1", "M", 0.5, 0.5, 0.5, 0.5),
+                        "Product Name")
+        );
+        aProduct.changeCoverImage(Fixture.Products.imageCoverType());
+
+        final var aEntity = ProductJpaEntity.toEntity(aProduct);
+        aEntity.setCoverImage(null);
+
+        final var actualResult = Assertions.assertDoesNotThrow(() -> productRepository.save(aEntity).toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getId().getValue());
+        Assertions.assertEquals(aEntity.getName(), actualResult.getName());
+        Assertions.assertEquals(aEntity.getDescription(), actualResult.getDescription());
+        Assertions.assertEquals(aEntity.getPrice(), actualResult.getPrice());
+        Assertions.assertEquals(aEntity.getQuantity(), actualResult.getQuantity());
+        Assertions.assertEquals(aEntity.getCategoryId(), actualResult.getCategoryId().getValue());
+        Assertions.assertTrue(actualResult.getCoverImage().isEmpty());
+        Assertions.assertEquals(1, actualResult.getAttributes().size());
+        Assertions.assertEquals(0, actualResult.getImages().size());
+        Assertions.assertEquals(aEntity.getCreatedAt(), actualResult.getCreatedAt());
+        Assertions.assertEquals(aEntity.getUpdatedAt(), actualResult.getUpdatedAt());
+    }
 }


### PR DESCRIPTION
## Descrição

Foi refatorado a parte de adição de uma imagem em um produto, removido cover image do array de images

## Mudanças Propostas

Foi refatorado a parte de adição de uma imagem em um produto, removido cover image do array de images

## Testes Realizados

N/A

## Cobertura de Testes

O mínimo é 95%, está em 100%

## Problemas Conhecidos

Hoje geramos um Id para o product image e na url que vai salva no banco vai outro id, o certo seria ter o mesmo id. Também precisamos adicionar um método ```generateWithoutSpaces()``` para gerar um id sem os hifens, alterar de ```varchar(36)``` para ```char(32)``` ocupando menos espaço, mas manter o ```generate()``` com os hifens para quando quiser usar já existir.

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
