### PR TITLE
Feature/add identifier generate without dash

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/media/upload/DefaultUploadProductImageUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/media/upload/DefaultUploadProductImageUseCase.java
@@ -30,9 +30,9 @@ public class DefaultUploadProductImageUseCase extends UploadProductImageUseCase 
         final var aResource = input.productImageResource();
 
         switch (aResource.type()) {
-            case COVER -> {
-                aProduct.getCoverImage().ifPresent(this.mediaResourceGateway::clearImage);
-                aProduct.changeCoverImage(this.mediaResourceGateway.storeImage(aProductId, aResource));
+            case BANNER -> {
+                aProduct.getBannerImage().ifPresent(this.mediaResourceGateway::clearImage);
+                aProduct.changeBannerImage(this.mediaResourceGateway.storeImage(aProductId, aResource));
             }
             case GALLERY -> aProduct.addImage(this.mediaResourceGateway.storeImage(aProductId, aResource));
             default -> throw DomainException.with(new Error("'productImageType' not implemented"));

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageUseCaseTest.java
@@ -33,14 +33,14 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
     private DefaultUploadProductImageUseCase uploadProductImageUseCase;
 
     @Test
-    void givenAValidParamsWithCoverType_whenCallExecuteWithProductContainsCoverImage_shouldUploadProductImage() {
-        final var aProductImage = Fixture.Products.imageCoverType();
+    void givenAValidParamsWithBannerType_whenCallExecuteWithProductContainsBannerImage_shouldUploadProductImage() {
+        final var aProductImage = Fixture.Products.imageBannerType();
         final var aProduct = Fixture.Products.tshirt();
-        final var aProductImageResource = Fixture.Products.imageCoverTypeResource();
-        aProduct.changeCoverImage(ProductImage.with(
+        final var aProductImageResource = Fixture.Products.imageBannerTypeResource();
+        aProduct.changeBannerImage(ProductImage.with(
                 "image.png",
-                "COVER-image.png",
-                "http://localhost:8080/COVER-image.png"
+                "BANNER-image.png",
+                "http://localhost:8080/BANNER-image.png"
         ));
 
         final var aProductId = aProduct.getId().getValue();
@@ -56,7 +56,7 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
         final var aOutput = this.uploadProductImageUseCase.execute(aCommand);
 
         Assertions.assertNotNull(aOutput);
-        Assertions.assertEquals(ProductImageType.COVER.name(), aOutput.productImageType().name());
+        Assertions.assertEquals(ProductImageType.BANNER.name(), aOutput.productImageType().name());
         Assertions.assertEquals(aProductId, aOutput.productId());
 
         Mockito.verify(productGateway, Mockito.times(1)).findById(aProductId);
@@ -64,15 +64,15 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
         Mockito.verify(mediaResourceGateway, Mockito.times(1)).storeImage(aProduct.getId(), aProductImageResource);
         Mockito.verify(productGateway, Mockito.times(1)).update(argThat(aCmd ->
                 Objects.equals(aProductId, aCmd.getId().getValue())
-                        && Objects.equals(aProductImage.id(), aCmd.getCoverImage().get().id())
-                        && Objects.equals(aProductImage.location(), aCmd.getCoverImage().get().location())));
+                        && Objects.equals(aProductImage.id(), aCmd.getBannerImage().get().id())
+                        && Objects.equals(aProductImage.location(), aCmd.getBannerImage().get().location())));
     }
 
     @Test
-    void givenAValidParamsWithCoverType_whenCallExecuteWithProductNotContainsCoverImage_shouldUploadProductImage() {
-        final var aProductImage = Fixture.Products.imageCoverType();
+    void givenAValidParamsWithBannerType_whenCallExecuteWithProductNotContainsBannerImage_shouldUploadProductImage() {
+        final var aProductImage = Fixture.Products.imageBannerType();
         final var aProduct = Fixture.Products.tshirt();
-        final var aProductImageResource = Fixture.Products.imageCoverTypeResource();
+        final var aProductImageResource = Fixture.Products.imageBannerTypeResource();
 
         final var aProductId = aProduct.getId().getValue();
 
@@ -86,7 +86,7 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
         final var aOutput = this.uploadProductImageUseCase.execute(aCommand);
 
         Assertions.assertNotNull(aOutput);
-        Assertions.assertEquals(ProductImageType.COVER.name(), aOutput.productImageType().name());
+        Assertions.assertEquals(ProductImageType.BANNER.name(), aOutput.productImageType().name());
         Assertions.assertEquals(aProductId, aOutput.productId());
 
         Mockito.verify(productGateway, Mockito.times(1)).findById(aProductId);
@@ -94,8 +94,8 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
         Mockito.verify(mediaResourceGateway, Mockito.times(1)).storeImage(aProduct.getId(), aProductImageResource);
         Mockito.verify(productGateway, Mockito.times(1)).update(argThat(aCmd ->
                 Objects.equals(aProductId, aCmd.getId().getValue())
-                        && Objects.equals(aProductImage.id(), aCmd.getCoverImage().get().id())
-                        && Objects.equals(aProductImage.location(), aCmd.getCoverImage().get().location())));
+                        && Objects.equals(aProductImage.id(), aCmd.getBannerImage().get().id())
+                        && Objects.equals(aProductImage.location(), aCmd.getBannerImage().get().location())));
     }
 
     @Test

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/Product.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/Product.java
@@ -20,7 +20,7 @@ public class Product extends AggregateRoot<ProductID> {
     private String description;
     private BigDecimal price;
     private int quantity;
-    private ProductImage coverImage;
+    private ProductImage bannerImage;
     private Set<ProductImage> images;
     private CategoryID categoryId;
     private Set<ProductAttributes> attributes;
@@ -33,7 +33,7 @@ public class Product extends AggregateRoot<ProductID> {
             final String aDescription,
             final BigDecimal aPrice,
             final int aQuantity,
-            final ProductImage aCoverImage,
+            final ProductImage aBannerImage,
             final Set<ProductImage> aImages,
             final CategoryID aCategoryId,
             final Set<ProductAttributes> aAttributes,
@@ -45,7 +45,7 @@ public class Product extends AggregateRoot<ProductID> {
         this.description = aDescription;
         this.price = aPrice;
         this.quantity = aQuantity;
-        this.coverImage = aCoverImage;
+        this.bannerImage = aBannerImage;
         this.images = aImages;
         this.categoryId = aCategoryId;
         this.attributes = aAttributes;
@@ -87,7 +87,7 @@ public class Product extends AggregateRoot<ProductID> {
             final String aDescription,
             final BigDecimal aPrice,
             final int aQuantity,
-            final ProductImage aCoverImage,
+            final ProductImage aBannerImage,
             final Set<ProductImage> aImages,
             final String aCategoryId,
             final Set<ProductAttributes> aAttributes,
@@ -100,7 +100,7 @@ public class Product extends AggregateRoot<ProductID> {
                 aDescription,
                 aPrice,
                 aQuantity,
-                aCoverImage,
+                aBannerImage,
                 new HashSet<>(aImages == null ? Collections.emptySet() : aImages),
                 CategoryID.from(aCategoryId),
                 new HashSet<>(aAttributes == null ? Collections.emptySet() : aAttributes),
@@ -116,7 +116,7 @@ public class Product extends AggregateRoot<ProductID> {
                 aProduct.getDescription(),
                 aProduct.getPrice(),
                 aProduct.getQuantity(),
-                aProduct.getCoverImage().orElse(null),
+                aProduct.getBannerImage().orElse(null),
                 new HashSet<>(aProduct.getImages()),
                 aProduct.getCategoryId(),
                 new HashSet<>(aProduct.getAttributes()),
@@ -137,8 +137,8 @@ public class Product extends AggregateRoot<ProductID> {
         this.images.add(aImage);
     }
 
-    public void changeCoverImage(final ProductImage aImage) {
-        this.coverImage = aImage;
+    public void changeBannerImage(final ProductImage aImage) {
+        this.bannerImage = aImage;
     }
 
     @Override
@@ -162,8 +162,8 @@ public class Product extends AggregateRoot<ProductID> {
         return quantity;
     }
 
-    public Optional<ProductImage> getCoverImage() {
-        return Optional.ofNullable(coverImage);
+    public Optional<ProductImage> getBannerImage() {
+        return Optional.ofNullable(bannerImage);
     }
 
     public Set<ProductImage> getImages() {

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductImageType.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductImageType.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 public enum ProductImageType {
 
-    COVER,
+    BANNER,
     GALLERY,
     INVALID_TYPE;
 

--- a/domain/src/main/java/com/kaua/ecommerce/domain/utils/IdUtils.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/utils/IdUtils.java
@@ -9,4 +9,8 @@ public final class IdUtils {
     public static String generate() {
         return UUID.randomUUID().toString().toLowerCase();
     }
+
+    public static String generateWithoutDash() {
+        return UUID.randomUUID().toString().replace("-", "").toLowerCase();
+    }
 }

--- a/domain/src/test/java/com/kaua/ecommerce/domain/Fixture.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/Fixture.java
@@ -150,20 +150,20 @@ public final class Fixture {
                         "Camiseta")
         );
 
-        private static final ProductImage imageCoverType = ProductImage.with(
+        private static final ProductImage imageBannerType = ProductImage.with(
                 IdUtils.generate(),
                 "image-one.jpg",
-                "COVER-image-one.jpg",
-                "https://localhost.com/COVER-image-one.jpg"
+                "BANNER-image-one.jpg",
+                "https://localhost.com/BANNER-image-one.jpg"
         );
 
-        private static final ProductImageResource imageCoverTypeResource = ProductImageResource.with(
+        private static final ProductImageResource imageBannerTypeResource = ProductImageResource.with(
                 Resource.with(
                         "image-one".getBytes(),
                         "image/png",
                         "image-one.jpg"
                 ),
-                ProductImageType.COVER
+                ProductImageType.BANNER
         );
 
         private static final ProductImage imageGalleryType = ProductImage.with(
@@ -186,19 +186,19 @@ public final class Fixture {
             return Product.with(tshirt);
         }
 
-        public static ProductImage imageCoverType() {
+        public static ProductImage imageBannerType() {
             return ProductImage.with(
-                    imageCoverType.id(),
-                    imageCoverType.name(),
-                    imageCoverType.location(),
-                    imageCoverType.url()
+                    imageBannerType.id(),
+                    imageBannerType.name(),
+                    imageBannerType.location(),
+                    imageBannerType.url()
             );
         }
 
-        public static ProductImageResource imageCoverTypeResource() {
+        public static ProductImageResource imageBannerTypeResource() {
             return ProductImageResource.with(
-                    imageCoverTypeResource.resource(),
-                    imageCoverTypeResource.type()
+                    imageBannerTypeResource.resource(),
+                    imageBannerTypeResource.type()
             );
         }
 

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductImageResourceTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductImageResourceTest.java
@@ -16,12 +16,12 @@ public class ProductImageResourceTest {
 
         final var actualProductImageResource = ProductImageResource.with(
                 aResource,
-                ProductImageType.COVER
+                ProductImageType.BANNER
         );
 
         Assertions.assertNotNull(actualProductImageResource);
         Assertions.assertEquals(aResource, actualProductImageResource.resource());
-        Assertions.assertEquals(ProductImageType.COVER, actualProductImageResource.type());
+        Assertions.assertEquals(ProductImageType.BANNER, actualProductImageResource.type());
     }
 
     @Test
@@ -32,7 +32,7 @@ public class ProductImageResourceTest {
                         "image/png",
                         "image.png"
                 ),
-                ProductImageType.COVER
+                ProductImageType.BANNER
         );
         final var anotherProductImageResource = ProductImageResource.with(
                 Resource.with(
@@ -40,7 +40,7 @@ public class ProductImageResourceTest {
                         "image/png",
                         "image.png"
                 ),
-                ProductImageType.COVER
+                ProductImageType.BANNER
         );
 
         Assertions.assertTrue(aProductImageResource.equals(anotherProductImageResource));
@@ -57,7 +57,7 @@ public class ProductImageResourceTest {
                         "image/png",
                         "image.png"
                 ),
-                ProductImageType.COVER
+                ProductImageType.BANNER
         );
         final var anotherProductImageResource = ProductImageResource.with(
                 Resource.with(
@@ -82,7 +82,7 @@ public class ProductImageResourceTest {
                         "image/png",
                         "image.png"
                 ),
-                ProductImageType.COVER
+                ProductImageType.BANNER
         );
         final var anotherProductImageResource = ProductImageResource.with(
                 Resource.with(
@@ -90,7 +90,7 @@ public class ProductImageResourceTest {
                         "image/png",
                         "image.png"
                 ),
-                ProductImageType.COVER
+                ProductImageType.BANNER
         );
 
         Assertions.assertNotEquals(aProductImageResource.hashCode(), anotherProductImageResource.hashCode());

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductImageTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductImageTest.java
@@ -1,5 +1,6 @@
 package com.kaua.ecommerce.domain.product;
 
+import com.kaua.ecommerce.domain.utils.IdUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ public class ProductImageTest {
 
     @Test
     void givenAValidValuesWithId_whenCallWith_shouldBeInstantiateProductImage() {
-        final var aId = "abc";
+        final var aId = IdUtils.generateWithoutDash();
         final var aName = "product.jpg";
         final var aLocation = "/images/product.jpg";
         final var aUrl = "http://localhost:8080/images/product.jpg";

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductTest.java
@@ -35,7 +35,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aDescription, aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
-        Assertions.assertTrue(aProduct.getCoverImage().isEmpty());
+        Assertions.assertTrue(aProduct.getBannerImage().isEmpty());
         Assertions.assertTrue(aProduct.getImages().isEmpty());
         Assertions.assertEquals(aCategoryId, aProduct.getCategoryId());
         Assertions.assertEquals(aAttributes, aProduct.getAttributes().stream().findFirst().get());
@@ -64,7 +64,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertNull(aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
-        Assertions.assertTrue(aProduct.getCoverImage().isEmpty());
+        Assertions.assertTrue(aProduct.getBannerImage().isEmpty());
         Assertions.assertTrue(aProduct.getImages().isEmpty());
         Assertions.assertEquals(aCategoryId, aProduct.getCategoryId());
         Assertions.assertEquals(aAttributes, aProduct.getAttributes().stream().findFirst().get());
@@ -92,7 +92,7 @@ public class ProductTest extends UnitTest {
         final var aDescription = "Product Description";
         final var aPrice = BigDecimal.valueOf(10.0);
         final var aQuantity = 10;
-        final var aCoverImage = ProductImage.with("abc", "cover-product.jpg", "/images/cover-product.jpg");
+        final var aBannerImage = ProductImage.with("abc", "banner-product.jpg", "/images/banner-product.jpg");
         final var aImage = ProductImage.with("abc", "product.jpg", "/images/product.jpg");
         final var aCategoryId = CategoryID.from("1");
         final var aAttributes = ProductAttributes.with(
@@ -109,7 +109,7 @@ public class ProductTest extends UnitTest {
                 aDescription,
                 aPrice,
                 aQuantity,
-                aCoverImage,
+                aBannerImage,
                 Set.of(aImage),
                 aCategoryId.getValue(),
                 Set.of(aAttributes),
@@ -122,7 +122,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aDescription, aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
-        Assertions.assertEquals(aCoverImage.location(), aProduct.getCoverImage().get().location());
+        Assertions.assertEquals(aBannerImage.location(), aProduct.getBannerImage().get().location());
         Assertions.assertEquals(aImage.location(), aProduct.getImages().stream().findFirst().get().location());
         Assertions.assertEquals(aCategoryId.getValue(), aProduct.getCategoryId().getValue());
         Assertions.assertEquals(aAttributes, aProduct.getAttributes().stream().findFirst().get());
@@ -141,7 +141,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aProductWith.getDescription(), aProduct.getDescription());
         Assertions.assertEquals(aProductWith.getPrice(), aProduct.getPrice());
         Assertions.assertEquals(aProductWith.getQuantity(), aProduct.getQuantity());
-        Assertions.assertTrue(aProductWith.getCoverImage().isEmpty());
+        Assertions.assertTrue(aProductWith.getBannerImage().isEmpty());
         Assertions.assertTrue(aProductWith.getImages().isEmpty());
         Assertions.assertEquals(aProductWith.getCategoryId().getValue(), aProduct.getCategoryId().getValue());
         Assertions.assertEquals(aProductWith.getAttributes(), aProduct.getAttributes());
@@ -156,7 +156,7 @@ public class ProductTest extends UnitTest {
         final var aDescription = "Product Description";
         final var aPrice = BigDecimal.valueOf(10.0);
         final var aQuantity = 10;
-        final var aCoverImage = ProductImage.with("abc", "cover-product.jpg", "/images/cover-product.jpg");
+        final var aBannerImage = ProductImage.with("abc", "banner-product.jpg", "/images/banner-product.jpg");
         final var aImage = ProductImage.with("abc", "product.jpg", "/images/product.jpg");
         final var aCategoryId = CategoryID.from("1");
         final Set<ProductAttributes> aAttributes = null;
@@ -169,7 +169,7 @@ public class ProductTest extends UnitTest {
                 aDescription,
                 aPrice,
                 aQuantity,
-                aCoverImage,
+                aBannerImage,
                 Set.of(aImage),
                 aCategoryId.getValue(),
                 aAttributes,
@@ -182,7 +182,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aDescription, aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
-        Assertions.assertEquals(aCoverImage.location(), aProduct.getCoverImage().get().location());
+        Assertions.assertEquals(aBannerImage.location(), aProduct.getBannerImage().get().location());
         Assertions.assertEquals(aImage.id(), aProduct.getImages().stream().findFirst().get().id());
         Assertions.assertEquals(aCategoryId.getValue(), aProduct.getCategoryId().getValue());
         Assertions.assertTrue(aProduct.getAttributes().isEmpty());
@@ -198,7 +198,7 @@ public class ProductTest extends UnitTest {
         final var aPrice = BigDecimal.valueOf(10.0);
         final var aQuantity = 10;
         final var aCategoryId = CategoryID.from("1");
-        final ProductImage aCoverImage = null;
+        final ProductImage aBannerImage = null;
         final Set<ProductImage> aImages = null;
         final var aAttributes = ProductAttributes.with(
                 ProductColor.with("1", "RED"),
@@ -214,7 +214,7 @@ public class ProductTest extends UnitTest {
                 aDescription,
                 aPrice,
                 aQuantity,
-                aCoverImage,
+                aBannerImage,
                 aImages,
                 aCategoryId.getValue(),
                 Set.of(aAttributes),
@@ -227,7 +227,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aDescription, aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
-        Assertions.assertTrue(aProduct.getCoverImage().isEmpty());
+        Assertions.assertTrue(aProduct.getBannerImage().isEmpty());
         Assertions.assertTrue(aProduct.getImages().isEmpty());
         Assertions.assertEquals(aCategoryId.getValue(), aProduct.getCategoryId().getValue());
         Assertions.assertEquals(aAttributes.sku(), aProduct.getAttributes().stream().findFirst().get().sku());
@@ -255,27 +255,27 @@ public class ProductTest extends UnitTest {
     }
 
     @Test
-    void givenAValidImage_whenCallChangeCoverImage_shouldChangeCoverImage() {
+    void givenAValidImage_whenCallChangeBannerImage_shouldChangeBannerImage() {
         final var aProduct = Fixture.Products.tshirt();
         final var aProductImageId = IdUtils.generate().replace("-", "");
         final var aLocation = aProduct.getId().getValue() +
                 "-" +
                 aProductImageId +
                 "-" +
-                ProductImageType.COVER.name() +
+                ProductImageType.BANNER.name() +
                 "-" +
                 "product.jpg";
         final var aUrl = "http://localhost:8080/images/product.jpg";
         final var aImage = ProductImage.with("abc", "product.jpg", aLocation, aUrl);
 
-        aProduct.changeCoverImage(aImage);
+        aProduct.changeBannerImage(aImage);
 
-        Assertions.assertEquals(aImage, aProduct.getCoverImage().get());
+        Assertions.assertEquals(aImage, aProduct.getBannerImage().get());
     }
 
     @Test
     void givenAValidType_whenCallProductImageTypeOf_shouldReturnProductImageType() {
-        final var aProductImageType = ProductImageType.COVER;
+        final var aProductImageType = ProductImageType.BANNER;
 
         final var aProductImageTypeOf = ProductImageType.of(aProductImageType.name());
 

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductMediaResourceGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductMediaResourceGateway.java
@@ -39,9 +39,8 @@ public class ProductMediaResourceGateway implements MediaResourceGateway {
 
     private ProductImage generateProductImage(ProductID aProductID, ProductImageResource aResource) {
         final var aImageResource = aResource.resource();
-        final var aProductImageId = IdUtils.generate().replace("-", "");
-        // TODO: Refactor buildLocation to receive aProductImageId as parameter, in this moment buildLocation use other random id
-        final var aLocation = buildLocation(aProductID, aResource);
+        final var aProductImageId = IdUtils.generateWithoutDash();
+        final var aLocation = buildLocation(aProductID, aResource, aProductImageId);
         final var aUrl = getProviderUrl().concat("/").concat(aLocation);
         return ProductImage.with(
                 aProductImageId,
@@ -60,13 +59,17 @@ public class ProductMediaResourceGateway implements MediaResourceGateway {
         return this.storageProperties.getProviderUrl();
     }
 
-    private String buildLocation(ProductID aProductID, ProductImageResource aResource) {
+    private String buildLocation(
+            final ProductID aProductID,
+            final ProductImageResource aResource,
+            final String aProductImageId
+    ) {
         final var aImageResource = aResource.resource();
         return aProductID.getValue()
                 .concat("-")
                 .concat(aResource.type().name())
                 .concat("-")
-                .concat(IdUtils.generate().replace("-", ""))
+                .concat(aProductImageId)
                 .concat("-")
                 .concat(aImageResource.fileName());
     }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductJpaEntity.java
@@ -36,8 +36,8 @@ public class ProductJpaEntity {
     private Set<ProductAttributesJpaEntity> attributes;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    @JoinColumn(name = "cover_image_id", referencedColumnName = "id")
-    private ProductImageJpaEntity coverImage;
+    @JoinColumn(name = "banner_image_id", referencedColumnName = "id")
+    private ProductImageJpaEntity bannerImage;
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Set<ProductImageRelationJpaEntity> images;
@@ -57,7 +57,7 @@ public class ProductJpaEntity {
             final BigDecimal price,
             final int quantity,
             final String categoryId,
-            final ProductImageJpaEntity coverImage,
+            final ProductImageJpaEntity bannerImage,
             final Instant createdAt,
             final Instant updatedAt
     ) {
@@ -68,7 +68,7 @@ public class ProductJpaEntity {
         this.quantity = quantity;
         this.categoryId = categoryId;
         this.attributes = new HashSet<>();
-        this.coverImage = coverImage;
+        this.bannerImage = bannerImage;
         this.images = new HashSet<>();
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -82,7 +82,7 @@ public class ProductJpaEntity {
                 aProduct.getPrice(),
                 aProduct.getQuantity(),
                 aProduct.getCategoryId().getValue(),
-                aProduct.getCoverImage().map(ProductImageJpaEntity::toEntity).orElse(null),
+                aProduct.getBannerImage().map(ProductImageJpaEntity::toEntity).orElse(null),
                 aProduct.getCreatedAt(),
                 aProduct.getUpdatedAt()
         );
@@ -100,7 +100,7 @@ public class ProductJpaEntity {
                 getDescription(),
                 getPrice(),
                 getQuantity(),
-                getCoverImage().map(ProductImageJpaEntity::toDomain).orElse(null),
+                getBannerImage().map(ProductImageJpaEntity::toDomain).orElse(null),
                 getImagesToDomain(),
                 getCategoryId(),
                 getAttributesToDomain(),
@@ -199,12 +199,12 @@ public class ProductJpaEntity {
         this.attributes = attributes;
     }
 
-    public Optional<ProductImageJpaEntity> getCoverImage() {
-        return Optional.ofNullable(coverImage);
+    public Optional<ProductImageJpaEntity> getBannerImage() {
+        return Optional.ofNullable(bannerImage);
     }
 
-    public void setCoverImage(ProductImageJpaEntity coverImage) {
-        this.coverImage = coverImage;
+    public void setBannerImage(ProductImageJpaEntity bannerImage) {
+        this.bannerImage = bannerImage;
     }
 
     public Set<ProductImageRelationJpaEntity> getImages() {

--- a/infrastructure/src/main/resources/db/migration/V5__CREATE_PRODUCTS_TABLE.sql
+++ b/infrastructure/src/main/resources/db/migration/V5__CREATE_PRODUCTS_TABLE.sql
@@ -12,10 +12,10 @@ CREATE TABLE products (
     price NUMERIC(19, 2) NOT NULL,
     quantity integer NOT NULL,
     category_id VARCHAR(36) NOT NULL,
-    cover_image_id VARCHAR(36),
+    banner_image_id VARCHAR(36),
     created_at DATETIME(6) NOT NULL,
     updated_at DATETIME(6) NOT NULL,
-    FOREIGN KEY (cover_image_id) REFERENCES products_images(id)
+    FOREIGN KEY (banner_image_id) REFERENCES products_images(id)
 );
 
 CREATE TABLE products_colors (

--- a/infrastructure/src/test/java/com/kaua/ecommerce/application/product/media/upload/UploadProductImageUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/application/product/media/upload/UploadProductImageUseCaseIT.java
@@ -21,7 +21,7 @@ public class UploadProductImageUseCaseIT {
     private UploadProductImageUseCase uploadProductImageUseCase;
 
     @Test
-    void givenAValidValuesWithCoverType_whenCallsUploadProductImage_shouldUploadImage() {
+    void givenAValidValuesWithBannerType_whenCallsUploadProductImage_shouldUploadImage() {
         // given
         final var aProduct = Fixture.Products.tshirt();
         final var aProductId = aProduct.getId().getValue();
@@ -32,7 +32,7 @@ public class UploadProductImageUseCaseIT {
 
         final var aCommand = UploadProductImageCommand.with(
                 aProductId,
-                Fixture.Products.imageCoverTypeResource()
+                Fixture.Products.imageBannerTypeResource()
         );
 
         // when
@@ -40,11 +40,11 @@ public class UploadProductImageUseCaseIT {
 
         // then
         Assertions.assertEquals(aProductId, actualResult.productId());
-        Assertions.assertEquals(ProductImageType.COVER.name(), actualResult.productImageType().name());
+        Assertions.assertEquals(ProductImageType.BANNER.name(), actualResult.productImageType().name());
 
         final var aProductEntity = this.productJpaRepository.findById(aProductId).get();
 
-        Assertions.assertTrue(aProductEntity.getCoverImage().isPresent());
+        Assertions.assertTrue(aProductEntity.getBannerImage().isPresent());
     }
 
     @Test

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/api/ProductAPITest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/api/ProductAPITest.java
@@ -693,7 +693,7 @@ public class ProductAPITest {
         // given
         final var aProduct = Fixture.Products.tshirt();
         final var aId = aProduct.getId().getValue();
-        final var aType = ProductImageType.COVER;
+        final var aType = ProductImageType.BANNER;
 
         final var aImage = new MockMultipartFile(
                 "media_file",
@@ -733,7 +733,7 @@ public class ProductAPITest {
         // given
         final var aProduct = Fixture.Products.tshirt();
         final var aId = aProduct.getId().getValue();
-        final var aType = ProductImageType.COVER;
+        final var aType = ProductImageType.BANNER;
 
         final var aImage = new MockMultipartFile(
                 "media_file",
@@ -765,7 +765,7 @@ public class ProductAPITest {
         // given
         final var aProduct = Fixture.Products.tshirt();
         final var aId = aProduct.getId().getValue();
-        final var aType = ProductImageType.COVER;
+        final var aType = ProductImageType.BANNER;
 
         final var aImage = new MockMultipartFile(
                 "media_file",
@@ -796,7 +796,7 @@ public class ProductAPITest {
     void givenAnInvalidProductId_whenCallUploadProductImage_thenShouldThrowNotFoundException() throws Exception {
         // given
         final var aId = "123";
-        final var aType = ProductImageType.COVER;
+        final var aType = ProductImageType.BANNER;
 
         final var aImage = new MockMultipartFile(
                 "media_file",

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductGatewayTest.java
@@ -79,7 +79,7 @@ public class ProductGatewayTest {
     @Test
     void givenAValidProductId_whenCallFindById_shouldReturnProduct() {
         final var aProduct = Fixture.Products.tshirt();
-        final var aProductImage = Fixture.Products.imageCoverType();
+        final var aProductImage = Fixture.Products.imageBannerType();
         aProduct.addImage(aProductImage);
         this.productRepository.save(ProductJpaEntity.toEntity(aProduct));
 
@@ -139,7 +139,7 @@ public class ProductGatewayTest {
     @Test
     void givenAValidProductWithImages_whenCallUpdate_shouldUpdateProduct() {
         final var aProduct = Fixture.Products.tshirt();
-        final var aProductImage = Fixture.Products.imageCoverType();
+        final var aProductImage = Fixture.Products.imageBannerType();
 
         this.productRepository.save(ProductJpaEntity.toEntity(aProduct));
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductMediaResourceGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductMediaResourceGatewayTest.java
@@ -38,7 +38,7 @@ public class ProductMediaResourceGatewayTest {
     void givenValidResource_whenCallsStorageImage_shouldStoreIt() {
         // given
         final var aProductId = ProductID.unique();
-        final var aResource = Fixture.Products.imageCoverTypeResource();
+        final var aResource = Fixture.Products.imageBannerTypeResource();
 
         // when
         final var actualMedia =
@@ -58,7 +58,7 @@ public class ProductMediaResourceGatewayTest {
     void givenValidResource_whenCallsClearImage_shouldDeleteImage() {
         // given
         final var aProductId = ProductID.unique();
-        final var aResource = Fixture.Products.imageCoverTypeResource();
+        final var aResource = Fixture.Products.imageBannerTypeResource();
 
         final var aProductImage = this.mediaResourceGateway.storeImage(aProductId, aResource);
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductJpaRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductJpaRepositoryTest.java
@@ -308,7 +308,7 @@ public class ProductJpaRepositoryTest {
                         ProductSize.with("1", "M", 0.5, 0.5, 0.5, 0.5),
                         "Product Name")
         );
-        aProduct.addImage(Fixture.Products.imageCoverType());
+        aProduct.addImage(Fixture.Products.imageBannerType());
 
         final var aEntity = ProductJpaEntity.toEntity(aProduct);
         aEntity.setImages(Set.of());
@@ -332,7 +332,7 @@ public class ProductJpaRepositoryTest {
         final var expectedErrorMessage = "ids for this class must be manually assigned before calling save(): com.kaua.ecommerce.infrastructure.product.persistence.ProductImageJpaEntity";
 
         final var aProduct = Fixture.Products.tshirt();
-        aProduct.addImage(Fixture.Products.imageCoverType());
+        aProduct.addImage(Fixture.Products.imageBannerType());
 
         final var aEntity = ProductJpaEntity.toEntity(aProduct);
         final var aProductImage = aEntity.getImages().stream().findFirst().get().getImage();
@@ -350,13 +350,13 @@ public class ProductJpaRepositoryTest {
     @Test
     void givenAValidProductImageValues_whenCallSave_shouldReturnProductWithProductImages() {
         final var aProduct = Fixture.Products.tshirt();
-        aProduct.addImage(Fixture.Products.imageCoverType());
+        aProduct.addImage(Fixture.Products.imageBannerType());
 
         final var aEntity = ProductJpaEntity.toEntity(aProduct);
         final var aProductImage = aEntity.getImages().stream().findFirst().get().getImage();
         aProductImage.setName("image.jpg");
-        aProductImage.setLocation("1234-COVER-567890-image.jpg");
-        aProductImage.setUrl("http://localhost:8080/1234-COVER-567890-image.jpg");
+        aProductImage.setLocation("1234-BANNER-567890-image.jpg");
+        aProductImage.setUrl("http://localhost:8080/1234-BANNER-567890-image.jpg");
 
         final var aProductImageDomain = aProductImage.toDomain();
 
@@ -385,7 +385,7 @@ public class ProductJpaRepositoryTest {
     }
 
     @Test
-    void givenAValidNullCoverImage_whenCallSave_shouldReturnProduct() {
+    void givenAValidNullBannerImage_whenCallSave_shouldReturnProduct() {
         final var aProduct = Product.newProduct(
                 "Product Name",
                 "Product Description",
@@ -397,10 +397,10 @@ public class ProductJpaRepositoryTest {
                         ProductSize.with("1", "M", 0.5, 0.5, 0.5, 0.5),
                         "Product Name")
         );
-        aProduct.changeCoverImage(Fixture.Products.imageCoverType());
+        aProduct.changeBannerImage(Fixture.Products.imageBannerType());
 
         final var aEntity = ProductJpaEntity.toEntity(aProduct);
-        aEntity.setCoverImage(null);
+        aEntity.setBannerImage(null);
 
         final var actualResult = Assertions.assertDoesNotThrow(() -> productRepository.save(aEntity).toDomain());
 
@@ -410,7 +410,7 @@ public class ProductJpaRepositoryTest {
         Assertions.assertEquals(aEntity.getPrice(), actualResult.getPrice());
         Assertions.assertEquals(aEntity.getQuantity(), actualResult.getQuantity());
         Assertions.assertEquals(aEntity.getCategoryId(), actualResult.getCategoryId().getValue());
-        Assertions.assertTrue(actualResult.getCoverImage().isEmpty());
+        Assertions.assertTrue(actualResult.getBannerImage().isEmpty());
         Assertions.assertEquals(1, actualResult.getAttributes().size());
         Assertions.assertEquals(0, actualResult.getImages().size());
         Assertions.assertEquals(aEntity.getCreatedAt(), actualResult.getCreatedAt());

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/service/impl/S3StorageServiceImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/service/impl/S3StorageServiceImplTest.java
@@ -37,7 +37,7 @@ public class S3StorageServiceImplTest {
                 "image/png",
                 aFileName
         );
-        final var aKey = IdUtils.generate() + "-" + "COVER" + "-" +
+        final var aKey = IdUtils.generate() + "-" + "BANNER" + "-" +
                 IdUtils.generate().replace("-", "")
                 + "-" + aFileName;
 
@@ -63,7 +63,7 @@ public class S3StorageServiceImplTest {
                 "image/png",
                 aFileName
         );
-        final var aKey = IdUtils.generate() + "-" + "COVER" + "-" +
+        final var aKey = IdUtils.generate() + "-" + "BANNER" + "-" +
                 IdUtils.generate().replace("-", "")
                 + "-" + aFileName;
 
@@ -83,7 +83,7 @@ public class S3StorageServiceImplTest {
     @Test
     void givenAValidLocation_whenCallDelete_thenShouldDeleteFile() {
         // given
-        final var aLocation = IdUtils.generate() + "-" + "COVER" + "-" +
+        final var aLocation = IdUtils.generate() + "-" + "BANNER" + "-" +
                 IdUtils.generate().replace("-", "")
                 + "-" + "product.png";
 
@@ -100,7 +100,7 @@ public class S3StorageServiceImplTest {
     @Test
     void givenAValidLocationButS3Throws_whenCallDelete_thenShouldThrowRuntimeException() {
         // given
-        final var aLocation = IdUtils.generate() + "-" + "COVER" + "-" +
+        final var aLocation = IdUtils.generate() + "-" + "BANNER" + "-" +
                 IdUtils.generate().replace("-", "")
                 + "-" + "product.png";
         final var expectedErrorMessage = "software.amazon.awssdk.services.s3.model.S3Exception";

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/service/local/InMemoryStorageServiceImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/service/local/InMemoryStorageServiceImplTest.java
@@ -26,7 +26,7 @@ public class InMemoryStorageServiceImplTest {
                 "image/png",
                 aFileName
         );
-        final var aKey = IdUtils.generate() + "-" + "COVER" + "-" +
+        final var aKey = IdUtils.generate() + "-" + "BANNER" + "-" +
                 IdUtils.generate().replace("-", "")
                 + "-" + aFileName;
 
@@ -46,7 +46,7 @@ public class InMemoryStorageServiceImplTest {
                 "image/png",
                 aFileName
         );
-        final var aKey = IdUtils.generate() + "-" + "COVER" + "-" +
+        final var aKey = IdUtils.generate() + "-" + "BANNER" + "-" +
                 IdUtils.generate().replace("-", "")
                 + "-" + aFileName;
 


### PR DESCRIPTION
## Descrição

Foi adicionado um método para gerar o uuid sem os hifens e foi alterado o nome de cover para banner

## Mudanças Propostas

Foi adicionado um método para gerar o uuid sem os hifens e foi alterado o nome de cover para banner

## Testes Realizados

N/A

## Cobertura de Testes

O mínimo é 95%, está em 100%

## Problemas Conhecidos

N/A

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
