### PR TITLE
Feature/upload product image usecase add multiples upload

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/exceptions/OnlyOneBannerImagePermittedException.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/exceptions/OnlyOneBannerImagePermittedException.java
@@ -1,0 +1,12 @@
+package com.kaua.ecommerce.application.exceptions;
+
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+
+import java.util.Collections;
+
+public class OnlyOneBannerImagePermittedException extends DomainException {
+
+    public OnlyOneBannerImagePermittedException() {
+        super("Only one banner image is allowed", Collections.emptyList());
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/create/DefaultCreateProductUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/create/DefaultCreateProductUseCase.java
@@ -55,8 +55,6 @@ public class DefaultCreateProductUseCase extends CreateProductUseCase {
         );
         aProduct.validate(aNotification);
 
-//        return Either.right(Output.from(this.productGateway.findById("f340ab1c-d692-4c40-bc63-1b823c7f68bb").get()));
-
         return aNotification.hasError()
                 ? Either.left(aNotification)
                 : Either.right(CreateProductOutput.from(this.productGateway.create(aProduct)));

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageCommand.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageCommand.java
@@ -2,15 +2,17 @@ package com.kaua.ecommerce.application.usecases.product.media.upload;
 
 import com.kaua.ecommerce.domain.product.ProductImageResource;
 
+import java.util.List;
+
 public record UploadProductImageCommand(
         String productId,
-        ProductImageResource productImageResource
+        List<ProductImageResource> productImagesResources
 ) {
 
     public static UploadProductImageCommand with(
             final String aProductId,
-            final ProductImageResource aProductImageResource
+            final List<ProductImageResource> aProductImagesResources
     ) {
-        return new UploadProductImageCommand(aProductId, aProductImageResource);
+        return new UploadProductImageCommand(aProductId, aProductImagesResources);
     }
 }

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageOutput.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageOutput.java
@@ -1,14 +1,10 @@
 package com.kaua.ecommerce.application.usecases.product.media.upload;
 
 import com.kaua.ecommerce.domain.product.Product;
-import com.kaua.ecommerce.domain.product.ProductImageType;
 
-public record UploadProductImageOutput(String productId, ProductImageType productImageType) {
+public record UploadProductImageOutput(String productId) {
 
-    public static UploadProductImageOutput from(
-            final Product aProduct,
-            final ProductImageType aType
-    ) {
-        return new UploadProductImageOutput(aProduct.getId().getValue(), aType);
+    public static UploadProductImageOutput from(final Product aProduct) {
+        return new UploadProductImageOutput(aProduct.getId().getValue());
     }
 }

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductImage.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductImage.java
@@ -29,7 +29,7 @@ public class ProductImage extends ValueObject {
             final String location,
             final String url
     ) {
-        return new ProductImage(IdUtils.generate(), name, location, url);
+        return new ProductImage(IdUtils.generateWithoutDash(), name, location, url);
     }
 
     public static ProductImage with(

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/api/ProductAPI.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/api/ProductAPI.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Tag(name = "Product")
 @RequestMapping(value = "products")
 public interface ProductAPI {
@@ -33,7 +35,7 @@ public interface ProductAPI {
     )
     @Operation(summary = "Upload a product image by type")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Updated successfully"),
+            @ApiResponse(responseCode = "201", description = "Images stored and linked in product successfully"),
             @ApiResponse(responseCode = "404", description = "A product id was not found"),
             @ApiResponse(responseCode = "422", description = "A validation error was thrown"),
             @ApiResponse(responseCode = "500", description = "An internal server error was thrown")
@@ -41,6 +43,6 @@ public interface ProductAPI {
     ResponseEntity<?> uploadProductImageByType(
             @PathVariable String id,
             @PathVariable String type,
-            @RequestParam("media_file") MultipartFile media
+            @RequestParam("media_file") List<MultipartFile> media
     );
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/impl/S3StorageServiceImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/impl/S3StorageServiceImpl.java
@@ -5,6 +5,7 @@ import com.kaua.ecommerce.infrastructure.service.StorageService;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.util.Objects;
@@ -26,6 +27,7 @@ public class S3StorageServiceImpl implements StorageService {
                     .bucket(bucketName)
                     .key(aKey)
                     .contentType(aResource.contentType())
+                    .acl(ObjectCannedACL.PUBLIC_READ)
                     .build();
 
             this.s3Client.putObject(aRequest, RequestBody

--- a/infrastructure/src/main/resources/db/migration/V5__CREATE_PRODUCTS_TABLE.sql
+++ b/infrastructure/src/main/resources/db/migration/V5__CREATE_PRODUCTS_TABLE.sql
@@ -14,8 +14,7 @@ CREATE TABLE products (
     category_id VARCHAR(36) NOT NULL,
     banner_image_id VARCHAR(36),
     created_at DATETIME(6) NOT NULL,
-    updated_at DATETIME(6) NOT NULL,
-    FOREIGN KEY (banner_image_id) REFERENCES products_images(id)
+    updated_at DATETIME(6) NOT NULL
 );
 
 CREATE TABLE products_colors (

--- a/infrastructure/src/test/java/com/kaua/ecommerce/application/product/media/upload/UploadProductImageUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/application/product/media/upload/UploadProductImageUseCaseIT.java
@@ -3,13 +3,14 @@ package com.kaua.ecommerce.application.product.media.upload;
 import com.kaua.ecommerce.application.usecases.product.media.upload.UploadProductImageCommand;
 import com.kaua.ecommerce.application.usecases.product.media.upload.UploadProductImageUseCase;
 import com.kaua.ecommerce.domain.Fixture;
-import com.kaua.ecommerce.domain.product.ProductImageType;
 import com.kaua.ecommerce.infrastructure.IntegrationTest;
 import com.kaua.ecommerce.infrastructure.product.persistence.ProductJpaEntity;
 import com.kaua.ecommerce.infrastructure.product.persistence.ProductJpaRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
 
 @IntegrationTest
 public class UploadProductImageUseCaseIT {
@@ -32,7 +33,7 @@ public class UploadProductImageUseCaseIT {
 
         final var aCommand = UploadProductImageCommand.with(
                 aProductId,
-                Fixture.Products.imageBannerTypeResource()
+                List.of(Fixture.Products.imageBannerTypeResource())
         );
 
         // when
@@ -40,7 +41,6 @@ public class UploadProductImageUseCaseIT {
 
         // then
         Assertions.assertEquals(aProductId, actualResult.productId());
-        Assertions.assertEquals(ProductImageType.BANNER.name(), actualResult.productImageType().name());
 
         final var aProductEntity = this.productJpaRepository.findById(aProductId).get();
 
@@ -59,7 +59,7 @@ public class UploadProductImageUseCaseIT {
 
         final var aCommand = UploadProductImageCommand.with(
                 aProductId,
-                Fixture.Products.imageGalleryTypeResource()
+                List.of(Fixture.Products.imageGalleryTypeResource())
         );
 
         // when
@@ -67,7 +67,6 @@ public class UploadProductImageUseCaseIT {
 
         // then
         Assertions.assertEquals(aProductId, actualResult.productId());
-        Assertions.assertEquals(ProductImageType.GALLERY.name(), actualResult.productImageType().name());
 
         final var aProductEntity = this.productJpaRepository.findById(aProductId).get();
 


### PR DESCRIPTION
## Descrição

Foi adicionado a função de fazer upload de N imagens

## Mudanças Propostas

Foi adicionado a função de fazer upload de N imagens

## Testes Realizados

Testes de integração e unidade

## Cobertura de Testes

O mínimo é 95%, está em 100%

## Problemas Conhecidos

Hoje um produto só pode ser criado com 1 atributo

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
