### PR TITLE
Refactor/delete product usecase

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/delete/DefaultDeleteProductUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/delete/DefaultDeleteProductUseCase.java
@@ -1,32 +1,25 @@
 package com.kaua.ecommerce.application.usecases.product.delete;
 
-import com.kaua.ecommerce.application.gateways.MediaResourceGateway;
 import com.kaua.ecommerce.application.gateways.ProductGateway;
+import com.kaua.ecommerce.domain.product.ProductStatus;
+import com.kaua.ecommerce.domain.product.events.ProductDeletedEvent;
 
 import java.util.Objects;
 
 public class DefaultDeleteProductUseCase extends DeleteProductUseCase {
 
     private final ProductGateway productGateway;
-    private final MediaResourceGateway mediaResourceGateway;
 
-    public DefaultDeleteProductUseCase(
-            final ProductGateway productGateway,
-            final MediaResourceGateway mediaResourceGateway
-    ) {
+    public DefaultDeleteProductUseCase(final ProductGateway productGateway) {
         this.productGateway = Objects.requireNonNull(productGateway);
-        this.mediaResourceGateway = Objects.requireNonNull(mediaResourceGateway);
     }
 
-    // TODO: refactor this method to publish an event to delete the product and its images from the storage
-    // before persisting the delete event inactivate product in database
     @Override
     public void execute(String aId) {
-        this.productGateway.findById(aId).ifPresent(product -> {
-            this.productGateway.delete(aId);
-            product.getBannerImage().ifPresent(this.mediaResourceGateway::clearImage);
-            if (!product.getImages().isEmpty())
-                this.mediaResourceGateway.clearImages(product.getImages());
+        this.productGateway.findById(aId).ifPresent(aProduct -> {
+            aProduct.updateStatus(ProductStatus.DELETED);
+            aProduct.registerEvent(ProductDeletedEvent.from(aProduct));
+            this.productGateway.update(aProduct);
         });
     }
 }

--- a/domain/src/main/java/com/kaua/ecommerce/domain/event/EventsTypes.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/event/EventsTypes.java
@@ -8,6 +8,7 @@ public final class EventsTypes {
 
     public static final String PRODUCT_CREATED = "product_created";
     public static final String PRODUCT_UPDATED = "product_updated";
+    public static final String PRODUCT_DELETED = "product_deleted";
 
     private EventsTypes() {}
 }

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/events/ProductDeletedEvent.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/events/ProductDeletedEvent.java
@@ -1,0 +1,29 @@
+package com.kaua.ecommerce.domain.product.events;
+
+import com.kaua.ecommerce.domain.event.DomainEvent;
+import com.kaua.ecommerce.domain.event.EventsTypes;
+import com.kaua.ecommerce.domain.product.Product;
+import com.kaua.ecommerce.domain.utils.InstantUtils;
+
+import java.time.Instant;
+
+public record ProductDeletedEvent(
+        String id,
+        String aggregateName,
+        String eventType,
+        Instant occurredOn
+) implements DomainEvent {
+
+    private ProductDeletedEvent(final String id) {
+        this(
+                id,
+                Product.class.getSimpleName().toLowerCase(),
+                EventsTypes.PRODUCT_DELETED,
+                InstantUtils.now()
+        );
+    }
+
+    public static ProductDeletedEvent from(final Product aProduct) {
+        return new ProductDeletedEvent(aProduct.getId().getValue());
+    }
+}

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductTest.java
@@ -6,6 +6,7 @@ import com.kaua.ecommerce.domain.category.CategoryID;
 import com.kaua.ecommerce.domain.event.EventsTypes;
 import com.kaua.ecommerce.domain.exceptions.DomainException;
 import com.kaua.ecommerce.domain.product.events.ProductCreatedEvent;
+import com.kaua.ecommerce.domain.product.events.ProductDeletedEvent;
 import com.kaua.ecommerce.domain.product.events.ProductUpdatedEvent;
 import com.kaua.ecommerce.domain.utils.IdUtils;
 import com.kaua.ecommerce.domain.utils.InstantUtils;
@@ -434,5 +435,33 @@ public class ProductTest extends UnitTest {
 
         Assertions.assertNotNull(aProductUpdated);
         Assertions.assertEquals(aProduct.getId().getValue(), aProductUpdated.id());
+    }
+
+    @Test
+    void givenAValidProduct_whenCallProductDeletedEventFrom_shouldReturnProductDeletedEvent() {
+        final var aName = "Product Name";
+        final var aDescription = "Product Description";
+        final var aPrice = BigDecimal.valueOf(10.0);
+        final var aQuantity = 10;
+        final var aCategoryId = CategoryID.from("1");
+        final var aAttributes = ProductAttributes.with(
+                ProductColor.with("1", "RED"),
+                ProductSize.with("1", "M", 0.5, 0.5, 0.5, 0.5),
+                aName
+        );
+
+        final var aProduct = Product.newProduct(
+                aName,
+                aDescription,
+                aPrice,
+                aQuantity,
+                aCategoryId,
+                Set.of(aAttributes));
+        final var aProductUpdatedStatus = aProduct.updateStatus(ProductStatus.DELETED);
+
+        final var aProductDeleted = ProductDeletedEvent.from(aProductUpdatedStatus);
+
+        Assertions.assertNotNull(aProductDeleted);
+        Assertions.assertEquals(aProduct.getId().getValue(), aProductDeleted.id());
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
@@ -50,6 +50,6 @@ public class ProductUseCaseConfig {
 
     @Bean
     public DeleteProductUseCase deleteProductUseCase() {
-        return new DefaultDeleteProductUseCase(productGateway, mediaResourceGateway);
+        return new DefaultDeleteProductUseCase(productGateway);
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/application/product/delete/DeleteProductUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/application/product/delete/DeleteProductUseCaseIT.java
@@ -3,6 +3,7 @@ package com.kaua.ecommerce.application.product.delete;
 import com.kaua.ecommerce.application.usecases.product.delete.DeleteProductUseCase;
 import com.kaua.ecommerce.domain.Fixture;
 import com.kaua.ecommerce.domain.product.ProductID;
+import com.kaua.ecommerce.domain.product.ProductStatus;
 import com.kaua.ecommerce.infrastructure.IntegrationTest;
 import com.kaua.ecommerce.infrastructure.product.persistence.ProductJpaEntity;
 import com.kaua.ecommerce.infrastructure.product.persistence.ProductJpaRepository;
@@ -30,11 +31,11 @@ public class DeleteProductUseCaseIT {
 
         Assertions.assertDoesNotThrow(() -> this.deleteProductUseCase.execute(aProductId));
 
-        Assertions.assertEquals(0, this.productRepository.count());
+        Assertions.assertEquals(1, this.productRepository.count());
 
         final var aPersistedProduct = this.productRepository.findById(aProductId);
 
-        Assertions.assertTrue(aPersistedProduct.isEmpty());
+        Assertions.assertEquals(ProductStatus.DELETED, aPersistedProduct.get().getStatus());
     }
 
     @Test


### PR DESCRIPTION
## Descrição

Foi removido a exclusão do produto e de suas imagens do s3, agora atualizamos o status para ```DELETED``` e salvamos um evento chamado ```product_deleted``` no futuro esse evento é enviado para uma fila e ai é feito a exclusão das imagens, do DB e do Elasticsearch

## Mudanças Propostas

N/A

## Testes Realizados

Testes de unidade e integração

## Cobertura de Testes

O mínimo é 95%, esta em 100%

## Problemas Conhecidos

N/A

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
