### PR TITLE
Feature/add save product in elasticsearch

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/media/upload/DefaultUploadProductImageUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/media/upload/DefaultUploadProductImageUseCase.java
@@ -53,8 +53,8 @@ public class DefaultUploadProductImageUseCase extends UploadProductImageUseCase 
             }
         });
 
-        this.productGateway.update(aProduct);
         aProduct.registerEvent(ProductUpdatedEvent.from(aProduct));
+        this.productGateway.update(aProduct);
 
         return UploadProductImageOutput.from(aProduct);
     }

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/search/save/SaveProductUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/search/save/SaveProductUseCase.java
@@ -1,0 +1,35 @@
+package com.kaua.ecommerce.application.usecases.product.search.save;
+
+import com.kaua.ecommerce.application.UseCase;
+import com.kaua.ecommerce.application.gateways.SearchGateway;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.product.Product;
+import com.kaua.ecommerce.domain.validation.Error;
+import com.kaua.ecommerce.domain.validation.handler.NotificationHandler;
+
+import java.util.Objects;
+
+public class SaveProductUseCase extends UseCase<Product, Product> {
+
+    private final SearchGateway<Product> productSearchGateway;
+
+    public SaveProductUseCase(final SearchGateway<Product> productSearchGateway) {
+        this.productSearchGateway = Objects.requireNonNull(productSearchGateway);
+    }
+
+    @Override
+    public Product execute(Product aProduct) {
+        if (aProduct == null) {
+            throw DomainException.with(new Error("Product cannot be null"));
+        }
+
+        final var aNotification = NotificationHandler.create();
+        aProduct.validate(aNotification);
+
+        if (aNotification.hasError()) {
+            throw DomainException.with(aNotification.getErrors());
+        }
+
+        return this.productSearchGateway.save(aProduct);
+    }
+}

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/product/create/CreateProductUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/product/create/CreateProductUseCaseTest.java
@@ -83,8 +83,8 @@ public class CreateProductUseCaseTest extends UseCaseTest {
                         && Objects.equals(aCmd.getQuantity(), aQuantity)
                         && aCmd.getImages().isEmpty()
                         && Objects.equals(aCmd.getCategoryId().getValue(), aCategoryId)
-                        && Objects.equals(aColorName, aCmd.getAttributes().stream().findFirst().get().color().color())
-                        && Objects.equals(aSizeName, aCmd.getAttributes().stream().findFirst().get().size().size())
+                        && Objects.equals(aColorName, aCmd.getAttributes().stream().findFirst().get().getColor().getColor())
+                        && Objects.equals(aSizeName, aCmd.getAttributes().stream().findFirst().get().getSize().getSize())
                         && Objects.equals(1, aCmd.getDomainEvents().size())
                         && Objects.nonNull(aCmd.getCreatedAt())
                         && Objects.nonNull(aCmd.getUpdatedAt())));

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageUseCaseTest.java
@@ -66,8 +66,8 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
         Mockito.verify(productGateway, Mockito.times(1)).update(argThat(aCmd ->
                 Objects.equals(aProductId, aCmd.getId().getValue())
                         && Objects.equals(1, aCmd.getDomainEvents().size())
-                        && Objects.equals(aProductImage.id(), aCmd.getBannerImage().get().id())
-                        && Objects.equals(aProductImage.location(), aCmd.getBannerImage().get().location())));
+                        && Objects.equals(aProductImage.getId(), aCmd.getBannerImage().get().getId())
+                        && Objects.equals(aProductImage.getLocation(), aCmd.getBannerImage().get().getLocation())));
     }
 
     @Test
@@ -96,8 +96,8 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
         Mockito.verify(productGateway, Mockito.times(1)).update(argThat(aCmd ->
                 Objects.equals(aProductId, aCmd.getId().getValue())
                         && Objects.equals(1, aCmd.getDomainEvents().size())
-                        && Objects.equals(aProductImage.id(), aCmd.getBannerImage().get().id())
-                        && Objects.equals(aProductImage.location(), aCmd.getBannerImage().get().location())));
+                        && Objects.equals(aProductImage.getId(), aCmd.getBannerImage().get().getId())
+                        && Objects.equals(aProductImage.getLocation(), aCmd.getBannerImage().get().getLocation())));
     }
 
     @Test
@@ -127,9 +127,9 @@ public class UploadProductImageUseCaseTest extends UseCaseTest {
                 Objects.equals(aProductId, aCmd.getId().getValue())
                         && Objects.equals(1, aCmd.getDomainEvents().size())
                         && Objects.equals(1, aCmd.getImages().size())
-                        && Objects.equals(aProductImage.id(), aCmd.getImages().stream().findFirst().get().id())
-                        && Objects.equals(aProductImage.name(), aCmd.getImages().stream().findFirst().get().name())
-                        && Objects.equals(aProductImage.location(), aCmd.getImages().stream().findFirst().get().location())));
+                        && Objects.equals(aProductImage.getId(), aCmd.getImages().stream().findFirst().get().getId())
+                        && Objects.equals(aProductImage.getName(), aCmd.getImages().stream().findFirst().get().getName())
+                        && Objects.equals(aProductImage.getLocation(), aCmd.getImages().stream().findFirst().get().getLocation())));
     }
 
     @Test

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/product/search/save/SaveProductUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/product/search/save/SaveProductUseCaseTest.java
@@ -1,0 +1,86 @@
+package com.kaua.ecommerce.application.usecases.product.search.save;
+
+import com.kaua.ecommerce.application.UseCaseTest;
+import com.kaua.ecommerce.application.gateways.SearchGateway;
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.domain.category.CategoryID;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.product.Product;
+import com.kaua.ecommerce.domain.product.ProductAttributes;
+import com.kaua.ecommerce.domain.product.ProductColor;
+import com.kaua.ecommerce.domain.product.ProductSize;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class SaveProductUseCaseTest extends UseCaseTest {
+
+    @Mock
+    private SearchGateway<Product> productSearchGateway;
+
+    @InjectMocks
+    private SaveProductUseCase useCase;
+
+    @Test
+    void givenAValidProduct_whenCallSave_shouldPersistProduct() {
+        final var aProduct = Fixture.Products.book();
+
+        Mockito.when(productSearchGateway.save(Mockito.any())).thenAnswer(returnsFirstArg());
+
+        this.useCase.execute(aProduct);
+
+        Mockito.verify(productSearchGateway, Mockito.times(1)).save(eq(aProduct));
+    }
+
+    @Test
+    void givenAnInvalidName_whenCallSave_shouldThrowsDomainException() {
+        final var aProduct = Product.newProduct(
+                " ",
+                "A good book",
+                BigDecimal.valueOf(10.0),
+                10,
+                CategoryID.unique(),
+                Set.of(ProductAttributes.create(
+                        ProductColor.with("Red"),
+                        ProductSize.with("M", 10.0, 10.0, 10.0, 10.0),
+                        " "
+                ))
+        );
+
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("name");
+        final var expectedErrorCount = 1;
+
+        final var actualError = Assertions.assertThrows(DomainException.class,
+                () -> this.useCase.execute(aProduct));
+
+        Assertions.assertEquals(expectedErrorMessage, actualError.getErrors().get(0).message());
+        Assertions.assertEquals(expectedErrorCount, actualError.getErrors().size());
+
+        Mockito.verify(productSearchGateway, Mockito.times(0)).save(eq(aProduct));
+    }
+
+    @Test
+    void givenAnInvalidNullCategory_whenCallSave_shouldThrowsDomainException() {
+        final Product aProduct = null;
+
+        final var expectedErrorMessage = "Product cannot be null";
+        final var expectedErrorCount = 1;
+
+        final var actualError = Assertions.assertThrows(DomainException.class,
+                () -> this.useCase.execute(aProduct));
+
+        Assertions.assertEquals(expectedErrorMessage, actualError.getErrors().get(0).message());
+        Assertions.assertEquals(expectedErrorCount, actualError.getErrors().size());
+
+        Mockito.verify(productSearchGateway, Mockito.times(0)).save(eq(aProduct));
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductAttributes.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductAttributes.java
@@ -50,12 +50,12 @@ public class ProductAttributes extends ValueObject {
     }
 
     private static String processProductColor(final ProductColor color) {
-        return color == null ? DEFAULT_SKU_VALUE : color.color().trim()
+        return color == null ? DEFAULT_SKU_VALUE : color.getColor().trim()
                 .replaceAll(REMOVE_WHITE_SPACES, "").toUpperCase();
     }
 
     private static String processProductSize(final ProductSize size) {
-        return size == null ? DEFAULT_SKU_VALUE : size.size().trim()
+        return size == null ? DEFAULT_SKU_VALUE : size.getSize().trim()
                 .replaceAll(REMOVE_WHITE_SPACES, "").toUpperCase();
     }
 
@@ -72,16 +72,16 @@ public class ProductAttributes extends ValueObject {
         return aProductNameFirstCharactersStrBuilder.toString().toUpperCase();
     }
 
-    public String sku() {
-        return sku;
-    }
-
-    public ProductColor color() {
+    public ProductColor getColor() {
         return color;
     }
 
-    public ProductSize size() {
+    public ProductSize getSize() {
         return size;
+    }
+
+    public String getSku() {
+        return sku;
     }
 
     @Override
@@ -94,6 +94,6 @@ public class ProductAttributes extends ValueObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(color, size, sku);
+        return Objects.hash(getColor(), getSize(), getSku());
     }
 }

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductColor.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductColor.java
@@ -23,11 +23,11 @@ public class ProductColor extends ValueObject {
         return new ProductColor(id, color.toUpperCase());
     }
 
-    public String id() {
+    public String getId() {
         return id;
     }
 
-    public String color() {
+    public String getColor() {
         return color;
     }
 }

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductImage.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductImage.java
@@ -3,9 +3,10 @@ package com.kaua.ecommerce.domain.product;
 import com.kaua.ecommerce.domain.ValueObject;
 import com.kaua.ecommerce.domain.utils.IdUtils;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public class ProductImage extends ValueObject {
+public class ProductImage extends ValueObject implements Serializable {
 
     private final String id;
     private final String name;
@@ -41,19 +42,19 @@ public class ProductImage extends ValueObject {
         return new ProductImage(id, name, location, url);
     }
 
-    public String id() {
+    public String getId() {
         return id;
     }
 
-    public String name() {
+    public String getName() {
         return name;
     }
 
-    public String location() {
+    public String getLocation() {
         return location;
     }
 
-    public String url() {
+    public String getUrl() {
         return url;
     }
 
@@ -67,6 +68,6 @@ public class ProductImage extends ValueObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, location, url);
+        return Objects.hash(getId(), getName(), getLocation(), getUrl());
     }
 }

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductSize.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductSize.java
@@ -51,27 +51,27 @@ public class ProductSize extends ValueObject {
         return new ProductSize(id, size.toUpperCase(), weight, height, width, depth);
     }
 
-    public String id() {
+    public String getId() {
         return id;
     }
 
-    public String size() {
+    public String getSize() {
         return size;
     }
 
-    public double weight() {
+    public double getWeight() {
         return weight;
     }
 
-    public double height() {
+    public double getHeight() {
         return height;
     }
 
-    public double width() {
+    public double getWidth() {
         return width;
     }
 
-    public double depth() {
+    public double getDepth() {
         return depth;
     }
 }

--- a/domain/src/test/java/com/kaua/ecommerce/domain/Fixture.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/Fixture.java
@@ -161,8 +161,8 @@ public final class Fixture {
         private static final Product BOOK = Product.newProduct(
                 "Livro",
                 "Livro de teste",
-                BigDecimal.valueOf(faker.random().nextDouble()),
-                faker.random().nextInt(),
+                BigDecimal.valueOf(faker.random().nextDouble(1, 999999)),
+                faker.random().nextInt(1, 100),
                 CategoryID.unique(),
                 Set.of(ProductAttributes.create(
                         ProductColor.with(faker.color().name()),

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductAttributesTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductAttributesTest.java
@@ -42,11 +42,9 @@ public class ProductAttributesTest {
 
         final var aProductAttributes = ProductAttributes.create(aColor, aSize, aProductName);
 
-        Assertions.assertEquals(aColor, aProductAttributes.color());
-        Assertions.assertEquals(aSize, aProductAttributes.size());
-        Assertions.assertNotNull(aProductAttributes.sku());
-
-        System.out.println(aProductAttributes.sku());
+        Assertions.assertEquals(aColor, aProductAttributes.getColor());
+        Assertions.assertEquals(aSize, aProductAttributes.getSize());
+        Assertions.assertNotNull(aProductAttributes.getSku());
     }
 
     @Test
@@ -57,9 +55,9 @@ public class ProductAttributesTest {
 
         final var aProductAttributes = ProductAttributes.with(aColor, aSize, aSku);
 
-        Assertions.assertEquals(aColor, aProductAttributes.color());
-        Assertions.assertEquals(aSize, aProductAttributes.size());
-        Assertions.assertEquals(aSku, aProductAttributes.sku());
+        Assertions.assertEquals(aColor, aProductAttributes.getColor());
+        Assertions.assertEquals(aSize, aProductAttributes.getSize());
+        Assertions.assertEquals(aSku, aProductAttributes.getSku());
     }
 
     @Test

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductColorTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductColorTest.java
@@ -10,8 +10,8 @@ public class ProductColorTest {
         final var aColor = "Red";
         final var aProductColor = ProductColor.with(aColor);
 
-        Assertions.assertEquals(aColor.toUpperCase(), aProductColor.color());
-        Assertions.assertNotNull(aProductColor.id());
+        Assertions.assertEquals(aColor.toUpperCase(), aProductColor.getColor());
+        Assertions.assertNotNull(aProductColor.getId());
     }
 
     @Test
@@ -20,8 +20,8 @@ public class ProductColorTest {
         final var aId = "1";
         final var aProductColor = ProductColor.with(aId, aColor);
 
-        Assertions.assertEquals(aColor.toUpperCase(), aProductColor.color());
-        Assertions.assertEquals(aId, aProductColor.id());
+        Assertions.assertEquals(aColor.toUpperCase(), aProductColor.getColor());
+        Assertions.assertEquals(aId, aProductColor.getId());
     }
 
     @Test

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductImageTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductImageTest.java
@@ -14,10 +14,10 @@ public class ProductImageTest {
 
         final var aProductImage = ProductImage.with(aName, aLocation, aUrl);
 
-        Assertions.assertNotNull(aProductImage.id());
-        Assertions.assertEquals(aName, aProductImage.name());
-        Assertions.assertEquals(aLocation, aProductImage.location());
-        Assertions.assertEquals(aUrl, aProductImage.url());
+        Assertions.assertNotNull(aProductImage.getId());
+        Assertions.assertEquals(aName, aProductImage.getName());
+        Assertions.assertEquals(aLocation, aProductImage.getLocation());
+        Assertions.assertEquals(aUrl, aProductImage.getUrl());
     }
 
     @Test
@@ -41,9 +41,10 @@ public class ProductImageTest {
 
         final var aProductImage = ProductImage.with(aId, aName, aLocation, aUrl);
 
-        Assertions.assertEquals(aId, aProductImage.id());
-        Assertions.assertEquals(aName, aProductImage.name());
-        Assertions.assertEquals(aLocation, aProductImage.location());
+        Assertions.assertEquals(aId, aProductImage.getId());
+        Assertions.assertEquals(aName, aProductImage.getName());
+        Assertions.assertEquals(aLocation, aProductImage.getLocation());
+        Assertions.assertEquals(aUrl, aProductImage.getUrl());
     }
 
     @Test

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductSizeTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductSizeTest.java
@@ -15,12 +15,12 @@ public class ProductSizeTest {
 
         final var aProductSize = ProductSize.with(aSize, aWeight, aHeight, aWidth, aDepth);
 
-        Assertions.assertNotNull(aProductSize.id());
-        Assertions.assertEquals(aSize, aProductSize.size());
-        Assertions.assertEquals(aWeight, aProductSize.weight());
-        Assertions.assertEquals(aHeight, aProductSize.height());
-        Assertions.assertEquals(aWidth, aProductSize.width());
-        Assertions.assertEquals(aDepth, aProductSize.depth());
+        Assertions.assertNotNull(aProductSize.getId());
+        Assertions.assertEquals(aSize, aProductSize.getSize());
+        Assertions.assertEquals(aWeight, aProductSize.getWeight());
+        Assertions.assertEquals(aHeight, aProductSize.getHeight());
+        Assertions.assertEquals(aWidth, aProductSize.getWidth());
+        Assertions.assertEquals(aDepth, aProductSize.getDepth());
     }
 
     @Test
@@ -34,12 +34,12 @@ public class ProductSizeTest {
 
         final var aProductSize = ProductSize.with(aId, aSize, aWeight, aHeight, aWidth, aDepth);
 
-        Assertions.assertEquals(aId, aProductSize.id());
-        Assertions.assertEquals(aSize, aProductSize.size());
-        Assertions.assertEquals(aWeight, aProductSize.weight());
-        Assertions.assertEquals(aHeight, aProductSize.height());
-        Assertions.assertEquals(aWidth, aProductSize.width());
-        Assertions.assertEquals(aDepth, aProductSize.depth());
+        Assertions.assertEquals(aId, aProductSize.getId());
+        Assertions.assertEquals(aSize, aProductSize.getSize());
+        Assertions.assertEquals(aWeight, aProductSize.getWeight());
+        Assertions.assertEquals(aHeight, aProductSize.getHeight());
+        Assertions.assertEquals(aWidth, aProductSize.getWidth());
+        Assertions.assertEquals(aDepth, aProductSize.getDepth());
     }
 
     @Test

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductTest.java
@@ -130,8 +130,8 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aDescription, aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
-        Assertions.assertEquals(aBannerImage.location(), aProduct.getBannerImage().get().location());
-        Assertions.assertEquals(aImage.location(), aProduct.getImages().stream().findFirst().get().location());
+        Assertions.assertEquals(aBannerImage.getLocation(), aProduct.getBannerImage().get().getLocation());
+        Assertions.assertEquals(aImage.getLocation(), aProduct.getImages().stream().findFirst().get().getLocation());
         Assertions.assertEquals(aCategoryId.getValue(), aProduct.getCategoryId().getValue());
         Assertions.assertEquals(aAttributes, aProduct.getAttributes().stream().findFirst().get());
         Assertions.assertEquals(aStatus, aProduct.getStatus());
@@ -194,8 +194,8 @@ public class ProductTest extends UnitTest {
         Assertions.assertEquals(aDescription, aProduct.getDescription());
         Assertions.assertEquals(aPrice, aProduct.getPrice());
         Assertions.assertEquals(aQuantity, aProduct.getQuantity());
-        Assertions.assertEquals(aBannerImage.location(), aProduct.getBannerImage().get().location());
-        Assertions.assertEquals(aImage.id(), aProduct.getImages().stream().findFirst().get().id());
+        Assertions.assertEquals(aBannerImage.getLocation(), aProduct.getBannerImage().get().getLocation());
+        Assertions.assertEquals(aImage.getId(), aProduct.getImages().stream().findFirst().get().getId());
         Assertions.assertEquals(aCategoryId.getValue(), aProduct.getCategoryId().getValue());
         Assertions.assertTrue(aProduct.getAttributes().isEmpty());
         Assertions.assertEquals(aStatus, aProduct.getStatus());
@@ -245,7 +245,7 @@ public class ProductTest extends UnitTest {
         Assertions.assertTrue(aProduct.getBannerImage().isEmpty());
         Assertions.assertTrue(aProduct.getImages().isEmpty());
         Assertions.assertEquals(aCategoryId.getValue(), aProduct.getCategoryId().getValue());
-        Assertions.assertEquals(aAttributes.sku(), aProduct.getAttributes().stream().findFirst().get().sku());
+        Assertions.assertEquals(aAttributes.getSku(), aProduct.getAttributes().stream().findFirst().get().getSku());
         Assertions.assertEquals(aStatus, aProduct.getStatus());
         Assertions.assertEquals(aCreatedAt, aProduct.getCreatedAt());
         Assertions.assertEquals(aUpdatedAt, aProduct.getUpdatedAt());

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
@@ -3,16 +3,19 @@ package com.kaua.ecommerce.infrastructure.configurations.usecases;
 import com.kaua.ecommerce.application.gateways.CategoryGateway;
 import com.kaua.ecommerce.application.gateways.MediaResourceGateway;
 import com.kaua.ecommerce.application.gateways.ProductGateway;
+import com.kaua.ecommerce.application.gateways.SearchGateway;
 import com.kaua.ecommerce.application.usecases.product.create.CreateProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.create.DefaultCreateProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.delete.DefaultDeleteProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.delete.DeleteProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.media.upload.DefaultUploadProductImageUseCase;
 import com.kaua.ecommerce.application.usecases.product.media.upload.UploadProductImageUseCase;
+import com.kaua.ecommerce.application.usecases.product.search.save.SaveProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.update.DefaultUpdateProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.update.UpdateProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.update.status.DefaultUpdateProductStatusUseCase;
 import com.kaua.ecommerce.application.usecases.product.update.status.UpdateProductStatusUseCase;
+import com.kaua.ecommerce.domain.product.Product;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,15 +27,18 @@ public class ProductUseCaseConfig {
     private final ProductGateway productGateway;
     private final CategoryGateway categoryGateway;
     private final MediaResourceGateway mediaResourceGateway;
+    private final SearchGateway<Product> productSearchGateway;
 
     public ProductUseCaseConfig(
             final ProductGateway productGateway,
             final CategoryGateway categoryGateway,
-            final MediaResourceGateway mediaResourceGateway
+            final MediaResourceGateway mediaResourceGateway,
+            final SearchGateway<Product> productSearchGateway
     ) {
         this.productGateway = Objects.requireNonNull(productGateway);
         this.categoryGateway = Objects.requireNonNull(categoryGateway);
         this.mediaResourceGateway = Objects.requireNonNull(mediaResourceGateway);
+        this.productSearchGateway = Objects.requireNonNull(productSearchGateway);
     }
 
     @Bean
@@ -58,5 +64,10 @@ public class ProductUseCaseConfig {
     @Bean
     public DeleteProductUseCase deleteProductUseCase() {
         return new DefaultDeleteProductUseCase(productGateway);
+    }
+
+    @Bean
+    public SaveProductUseCase saveProductUseCase() {
+        return new SaveProductUseCase(productSearchGateway);
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/listeners/ProductEventListener.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/listeners/ProductEventListener.java
@@ -1,0 +1,66 @@
+package com.kaua.ecommerce.infrastructure.listeners;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.kaua.ecommerce.application.gateways.ProductGateway;
+import com.kaua.ecommerce.application.usecases.product.search.save.SaveProductUseCase;
+import com.kaua.ecommerce.domain.event.EventsTypes;
+import com.kaua.ecommerce.domain.product.events.ProductCreatedEvent;
+import com.kaua.ecommerce.infrastructure.configurations.json.Json;
+import com.kaua.ecommerce.infrastructure.listeners.models.MessageValue;
+import com.kaua.ecommerce.infrastructure.outbox.OutboxEventEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class ProductEventListener {
+
+    public static final TypeReference<MessageValue<OutboxEventEntity>> PRODUCT_MESSAGE = new TypeReference<>() {
+    };
+    private static final Logger LOG = LoggerFactory.getLogger(ProductEventListener.class);
+
+    private final ProductGateway productGateway;
+    private final SaveProductUseCase saveProductUseCase;
+
+    public ProductEventListener(
+            final ProductGateway productGateway,
+            final SaveProductUseCase saveProductUseCase
+    ) {
+        this.productGateway = Objects.requireNonNull(productGateway);
+        this.saveProductUseCase = Objects.requireNonNull(saveProductUseCase);
+    }
+
+    @KafkaListener(
+            concurrency = "${kafka.consumers.products.concurrency}",
+            containerFactory = "kafkaListenerFactory",
+            topics = "${kafka.consumers.products.topics}",
+            groupId = "${kafka.consumers.products.group-id}",
+            id = "${kafka.consumers.products.id}",
+            properties = {
+                    "auto.offset.reset=${kafka.consumers.products.auto-offset-reset}"
+            }
+    )
+    public void onMessage(@Payload final String payload, final Acknowledgment ack) {
+        LOG.debug("Message received from Kafka: {}", payload);
+        final var aOutBoxEvent = Json.readValue(payload, PRODUCT_MESSAGE).payload().after();
+
+        switch (aOutBoxEvent.getEventType()) {
+            case EventsTypes.PRODUCT_CREATED -> {
+                final var aProductCreated = Json.readValue(aOutBoxEvent.getData(), ProductCreatedEvent.class);
+                final var aProductId = aProductCreated.id();
+                this.productGateway.findById(aProductId)
+                        .ifPresentOrElse(aProduct -> {
+                            this.saveProductUseCase.execute(aProduct);
+                            ack.acknowledge();
+                            LOG.debug("Product created received from Kafka: {}", aProductId);
+                        }, () -> LOG.debug("Product created not found in database: {}", aProductId));
+            }
+            default -> LOG.warn("Event type not supported: {}", aOutBoxEvent.getEventType());
+        }
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductElasticsearchGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductElasticsearchGateway.java
@@ -1,0 +1,48 @@
+package com.kaua.ecommerce.infrastructure.product;
+
+import com.kaua.ecommerce.application.gateways.SearchGateway;
+import com.kaua.ecommerce.domain.pagination.Pagination;
+import com.kaua.ecommerce.domain.pagination.SearchQuery;
+import com.kaua.ecommerce.domain.product.Product;
+import com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch.ProductElasticsearchEntity;
+import com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch.ProductElasticsearchRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Component
+public class ProductElasticsearchGateway implements SearchGateway<Product> {
+
+    private final ProductElasticsearchRepository productElasticsearchRepository;
+
+    public ProductElasticsearchGateway(final ProductElasticsearchRepository productElasticsearchRepository) {
+        this.productElasticsearchRepository = Objects.requireNonNull(productElasticsearchRepository);
+    }
+
+    @Override
+    public Product save(Product aggregateRoot) {
+        this.productElasticsearchRepository.save(ProductElasticsearchEntity.toEntity(aggregateRoot));
+        return aggregateRoot;
+    }
+
+    @Override
+    public Pagination<Product> findAll(SearchQuery aQuery) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Optional<Product> findById(String id) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Optional<Product> findByIdNested(String id) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void deleteById(String id) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductMediaResourceGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductMediaResourceGateway.java
@@ -35,13 +35,13 @@ public class ProductMediaResourceGateway implements MediaResourceGateway {
 
     @Override
     public void clearImage(ProductImage aImage) {
-        this.storageService.delete(aImage.location());
+        this.storageService.delete(aImage.getLocation());
     }
 
     @Override
     public void clearImages(Set<ProductImage> aImages) {
         final var aLocations = aImages.stream()
-                .map(ProductImage::location)
+                .map(ProductImage::getLocation)
                 .toList();
         this.storageService.deleteAllByLocation(aLocations);
     }
@@ -61,7 +61,7 @@ public class ProductMediaResourceGateway implements MediaResourceGateway {
 
     private void store(final ProductImage aProductImage, final ProductImageResource aResource) {
         final var aImageResource = aResource.resource();
-        this.storageService.store(aProductImage.location(), aImageResource);
+        this.storageService.store(aProductImage.getLocation(), aImageResource);
     }
 
     public String getProviderUrl() {

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductAttributesJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductAttributesJpaEntity.java
@@ -35,17 +35,17 @@ public class ProductAttributesJpaEntity {
     ) {
         this.id = ProductAttributesId.from(
                 product.getId(),
-                attributes.color().id(),
-                attributes.size().id()
+                attributes.getColor().getId(),
+                attributes.getSize().getId()
         );
-        this.color = ProductColorJpaEntity.toEntity(attributes.color());
-        this.size = ProductSizeJpaEntity.toEntity(attributes.size());
+        this.color = ProductColorJpaEntity.toEntity(attributes.getColor());
+        this.size = ProductSizeJpaEntity.toEntity(attributes.getSize());
         this.product = product;
         this.sku = sku;
     }
 
     public static ProductAttributesJpaEntity toEntity(final ProductAttributes attributes, final ProductJpaEntity product) {
-        return new ProductAttributesJpaEntity(attributes, product, attributes.sku());
+        return new ProductAttributesJpaEntity(attributes, product, attributes.getSku());
     }
 
     public ProductAttributesId getId() {

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductColorJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductColorJpaEntity.java
@@ -21,7 +21,7 @@ public class ProductColorJpaEntity {
     }
 
     public static ProductColorJpaEntity toEntity(final ProductColor aProductColor) {
-        return new ProductColorJpaEntity(aProductColor.id(), aProductColor.color());
+        return new ProductColorJpaEntity(aProductColor.getId(), aProductColor.getColor());
     }
 
     public ProductColor toDomain() {

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductImageJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductImageJpaEntity.java
@@ -40,10 +40,10 @@ public class ProductImageJpaEntity {
 
     public static ProductImageJpaEntity toEntity(ProductImage aProductImage) {
         return new ProductImageJpaEntity(
-                aProductImage.id(),
-                aProductImage.name(),
-                aProductImage.location(),
-                aProductImage.url()
+                aProductImage.getId(),
+                aProductImage.getName(),
+                aProductImage.getLocation(),
+                aProductImage.getUrl()
         );
     }
 

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductImageRelationJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductImageRelationJpaEntity.java
@@ -26,7 +26,7 @@ public class ProductImageRelationJpaEntity {
             final ProductJpaEntity product,
             final ProductImage image
     ) {
-        this.id = ProductImageRelationId.from(product.getId(), image.id());
+        this.id = ProductImageRelationId.from(product.getId(), image.getId());
         this.product = product;
         this.image = ProductImageJpaEntity.toEntity(image);
     }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductSizeJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductSizeJpaEntity.java
@@ -48,12 +48,12 @@ public class ProductSizeJpaEntity {
 
     public static ProductSizeJpaEntity toEntity(final ProductSize aProductSize) {
         return new ProductSizeJpaEntity(
-                aProductSize.id(),
-                aProductSize.size(),
-                aProductSize.weight(),
-                aProductSize.height(),
-                aProductSize.width(),
-                aProductSize.depth());
+                aProductSize.getId(),
+                aProductSize.getSize(),
+                aProductSize.getWeight(),
+                aProductSize.getHeight(),
+                aProductSize.getWidth(),
+                aProductSize.getDepth());
     }
 
     public ProductSize toDomain() {

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductAttributesElasticsearchEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductAttributesElasticsearchEntity.java
@@ -1,0 +1,47 @@
+package com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch;
+
+import com.kaua.ecommerce.domain.product.ProductAttributes;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Document(indexName = "product_attributes")
+public class ProductAttributesElasticsearchEntity {
+
+    @Field(name = "color", type = FieldType.Nested)
+    private ProductColorElasticsearchEntity color;
+
+    @Field(name = "size", type = FieldType.Nested)
+    private ProductSizeElasticsearchEntity size;
+
+    @Field(name = "sku", type = FieldType.Text)
+    private String sku;
+
+    public ProductAttributesElasticsearchEntity() {
+    }
+
+    private ProductAttributesElasticsearchEntity(
+            final ProductAttributes attributes,
+            final String sku
+    ) {
+        this.color = ProductColorElasticsearchEntity.toEntity(attributes.getColor());
+        this.size = ProductSizeElasticsearchEntity.toEntity(attributes.getSize());
+        this.sku = sku;
+    }
+
+    public static ProductAttributesElasticsearchEntity toEntity(final ProductAttributes attributes) {
+        return new ProductAttributesElasticsearchEntity(attributes, attributes.getSku());
+    }
+
+    public ProductColorElasticsearchEntity getColor() {
+        return color;
+    }
+
+    public ProductSizeElasticsearchEntity getSize() {
+        return size;
+    }
+
+    public String getSku() {
+        return sku;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductColorElasticsearchEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductColorElasticsearchEntity.java
@@ -1,0 +1,49 @@
+package com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch;
+
+import com.kaua.ecommerce.domain.product.ProductColor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Document(indexName = "product_colors")
+public class ProductColorElasticsearchEntity {
+
+    @Id
+    private String id;
+
+    @Field(name = "color", type = FieldType.Text)
+    private String color;
+
+    public ProductColorElasticsearchEntity() {
+    }
+
+    private ProductColorElasticsearchEntity(final String id, final String color) {
+        this.id = id;
+        this.color = color;
+    }
+
+    public static ProductColorElasticsearchEntity toEntity(final ProductColor aProductColor) {
+        return new ProductColorElasticsearchEntity(aProductColor.getId(), aProductColor.getColor());
+    }
+
+    public ProductColor toDomain() {
+        return ProductColor.with(getId(), getColor());
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductElasticsearchEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductElasticsearchEntity.java
@@ -1,0 +1,242 @@
+package com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch;
+
+import com.kaua.ecommerce.domain.product.Product;
+import com.kaua.ecommerce.domain.product.ProductAttributes;
+import com.kaua.ecommerce.domain.product.ProductImage;
+import com.kaua.ecommerce.domain.product.ProductStatus;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Document(indexName = "products")
+public class ProductElasticsearchEntity {
+
+    @Id
+    private String id;
+
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, name = "name"),
+            otherFields = @InnerField(suffix = "keyword", type = FieldType.Keyword)
+    )
+    private String name;
+
+    @Field(type = FieldType.Text, name = "description")
+    private String description;
+
+    private BigDecimal price;
+
+    @Field(type = FieldType.Integer, name = "quantity")
+    private int quantity;
+
+    @Field(type = FieldType.Nested, name = "banner_image")
+    private ProductImageElasticsearchEntity bannerImage;
+
+    @Field(type = FieldType.Nested, name = "images")
+    private Set<ProductImageElasticsearchEntity> images;
+
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, name = "category_id"),
+            otherFields = @InnerField(suffix = "keyword", type = FieldType.Keyword)
+    )
+    private String categoryId;
+
+    @Field(type = FieldType.Nested, name = "attributes")
+    private Set<ProductAttributesElasticsearchEntity> attributes;
+
+    private ProductStatus status;
+
+    @Field(type = FieldType.Date, name = "created_at")
+    private Instant createdAt;
+
+    @Field(type = FieldType.Date, name = "updated_at")
+    private Instant updatedAt;
+
+    public ProductElasticsearchEntity() {
+    }
+
+    public ProductElasticsearchEntity(
+            final String id,
+            final String name,
+            final String description,
+            final BigDecimal price,
+            final int quantity,
+            final ProductImageElasticsearchEntity bannerImage,
+            final String categoryId,
+            final ProductStatus status,
+            final Instant createdAt,
+            final Instant updatedAt
+    ) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.quantity = quantity;
+        this.bannerImage = bannerImage;
+        this.images = new HashSet<>();
+        this.categoryId = categoryId;
+        this.attributes = new HashSet<>();
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static ProductElasticsearchEntity toEntity(final Product aProduct) {
+        final var aEntity = new ProductElasticsearchEntity(
+                aProduct.getId().getValue(),
+                aProduct.getName(),
+                aProduct.getDescription(),
+                aProduct.getPrice(),
+                aProduct.getQuantity(),
+                aProduct.getBannerImage()
+                        .map(ProductImageElasticsearchEntity::toEntity)
+                        .orElse(null),
+                aProduct.getCategoryId().getValue(),
+                aProduct.getStatus(),
+                aProduct.getCreatedAt(),
+                aProduct.getUpdatedAt()
+        );
+
+        aProduct.getImages().forEach(aEntity::addImage);
+        aProduct.getAttributes().forEach(aEntity::addAttribute);
+
+        return aEntity;
+    }
+
+    public Product toDomain() {
+        return Product.with(
+                getId(),
+                getName(),
+                getDescription(),
+                getPrice(),
+                getQuantity(),
+                getBannerImage().map(ProductImageElasticsearchEntity::toDomain).orElse(null),
+                getImages().stream()
+                        .map(ProductImageElasticsearchEntity::toDomain)
+                        .collect(Collectors.toSet()),
+                getCategoryId(),
+                getAttributesDomain(),
+                getStatus(),
+                getCreatedAt(),
+                getUpdatedAt()
+        );
+    }
+
+    private Set<ProductAttributes> getAttributesDomain() {
+        return getAttributes()
+                .stream().map(attribute -> ProductAttributes.with(
+                        attribute.getColor().toDomain(),
+                        attribute.getSize().toDomain(),
+                        attribute.getSku()
+                )).collect(Collectors.toSet());
+    }
+
+    public void addImage(final ProductImage aImage) {
+        this.images.add(ProductImageElasticsearchEntity.toEntity(aImage));
+    }
+
+    public void addAttribute(final ProductAttributes aAttribute) {
+        this.attributes.add(ProductAttributesElasticsearchEntity.toEntity(aAttribute));
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public void setPrice(BigDecimal price) {
+        this.price = price;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public Optional<ProductImageElasticsearchEntity> getBannerImage() {
+        return Optional.ofNullable(bannerImage);
+    }
+
+    public void setBannerImage(ProductImageElasticsearchEntity bannerImage) {
+        this.bannerImage = bannerImage;
+    }
+
+    public Set<ProductImageElasticsearchEntity> getImages() {
+        return images;
+    }
+
+    public void setImages(Set<ProductImageElasticsearchEntity> images) {
+        this.images = images;
+    }
+
+    public String getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(String categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public Set<ProductAttributesElasticsearchEntity> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Set<ProductAttributesElasticsearchEntity> attributes) {
+        this.attributes = attributes;
+    }
+
+    public ProductStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ProductStatus status) {
+        this.status = status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductElasticsearchRepository.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductElasticsearchRepository.java
@@ -1,0 +1,6 @@
+package com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ProductElasticsearchRepository extends ElasticsearchRepository<ProductElasticsearchEntity, String> {
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductImageElasticsearchEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductImageElasticsearchEntity.java
@@ -1,0 +1,88 @@
+package com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch;
+
+import com.kaua.ecommerce.domain.product.ProductImage;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Document(indexName = "product_images")
+public class ProductImageElasticsearchEntity {
+
+    @Id
+    private String id;
+
+    @Field(name = "name", type = FieldType.Text)
+    private String name;
+
+    @Field(name = "location", type = FieldType.Text)
+    private String location;
+
+    @Field(name = "url", type = FieldType.Text)
+    private String url;
+
+    public ProductImageElasticsearchEntity() {
+    }
+
+    private ProductImageElasticsearchEntity(
+            final String id,
+            final String name,
+            final String location,
+            final String url
+    ) {
+        this.id = id;
+        this.name = name;
+        this.location = location;
+        this.url = url;
+    }
+
+    public static ProductImageElasticsearchEntity toEntity(ProductImage aProductImage) {
+        return new ProductImageElasticsearchEntity(
+                aProductImage.getId(),
+                aProductImage.getName(),
+                aProductImage.getLocation(),
+                aProductImage.getUrl()
+        );
+    }
+
+    public ProductImage toDomain() {
+        return ProductImage.with(
+                getId(),
+                getName(),
+                getLocation(),
+                getUrl()
+        );
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductSizeElasticsearchEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/persistence/elasticsearch/ProductSizeElasticsearchEntity.java
@@ -1,0 +1,110 @@
+package com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch;
+
+import com.kaua.ecommerce.domain.product.ProductSize;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Document(indexName = "product_sizes")
+public class ProductSizeElasticsearchEntity {
+
+    @Id
+    private String id;
+
+    @Field(name = "size", type = FieldType.Text)
+    private String size;
+
+    @Field(name = "weight", type = FieldType.Double)
+    private double weight;
+
+    @Field(name = "height", type = FieldType.Double)
+    private double height;
+
+    @Field(name = "width", type = FieldType.Double)
+    private double width;
+
+    @Field(name = "depth", type = FieldType.Double)
+    private double depth;
+
+    public ProductSizeElasticsearchEntity() {
+    }
+
+    private ProductSizeElasticsearchEntity(
+            final String id,
+            final String size,
+            final double weight,
+            final double height,
+            final double width,
+            final double depth
+    ) {
+        this.id = id;
+        this.size = size;
+        this.weight = weight;
+        this.height = height;
+        this.width = width;
+        this.depth = depth;
+    }
+
+    public static ProductSizeElasticsearchEntity toEntity(final ProductSize aProductSize) {
+        return new ProductSizeElasticsearchEntity(
+                aProductSize.getId(),
+                aProductSize.getSize(),
+                aProductSize.getWeight(),
+                aProductSize.getHeight(),
+                aProductSize.getWidth(),
+                aProductSize.getDepth());
+    }
+
+    public ProductSize toDomain() {
+        return ProductSize.with(getId(), getSize(), getWeight(), getHeight(), getWidth(), getDepth());
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getSize() {
+        return size;
+    }
+
+    public void setSize(String size) {
+        this.size = size;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public void setWeight(double weight) {
+        this.weight = weight;
+    }
+
+    public double getHeight() {
+        return height;
+    }
+
+    public void setHeight(double height) {
+        this.height = height;
+    }
+
+    public double getWidth() {
+        return width;
+    }
+
+    public void setWidth(double width) {
+        this.width = width;
+    }
+
+    public double getDepth() {
+        return depth;
+    }
+
+    public void setDepth(double depth) {
+        this.depth = depth;
+    }
+}

--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -40,6 +40,12 @@ kafka:
       id: kafka-listener-categories
       topics: category-topic
       group-id: categories-group
+    products:
+      auto-offset-reset: earliest
+      concurrency: 1
+      id: kafka-listener-products
+      topics: product-topic
+      group-id: products-group
 
 server:
   port: 8080

--- a/infrastructure/src/test/java/com/kaua/ecommerce/config/IntegrationTestConfiguration.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/config/IntegrationTestConfiguration.java
@@ -1,6 +1,7 @@
 package com.kaua.ecommerce.config;
 
 import com.kaua.ecommerce.infrastructure.category.persistence.CategoryElasticsearchRepository;
+import com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch.ProductElasticsearchRepository;
 import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
 
@@ -9,5 +10,10 @@ public class IntegrationTestConfiguration {
     @Bean
     public CategoryElasticsearchRepository categoryElasticsearchRepository() {
         return Mockito.mock(CategoryElasticsearchRepository.class);
+    }
+
+    @Bean
+    public ProductElasticsearchRepository productElasticsearchRepository() {
+        return Mockito.mock(ProductElasticsearchRepository.class);
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/ProductEventListenerTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/ProductEventListenerTest.java
@@ -1,0 +1,81 @@
+package com.kaua.ecommerce.infrastructure.listeners;
+
+import com.kaua.ecommerce.application.gateways.ProductGateway;
+import com.kaua.ecommerce.application.usecases.product.search.save.SaveProductUseCase;
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.domain.category.CategoryID;
+import com.kaua.ecommerce.domain.product.events.ProductCreatedEvent;
+import com.kaua.ecommerce.infrastructure.AbstractEmbeddedKafkaTest;
+import com.kaua.ecommerce.infrastructure.configurations.json.Json;
+import com.kaua.ecommerce.infrastructure.listeners.models.MessageValue;
+import com.kaua.ecommerce.infrastructure.listeners.models.Operation;
+import com.kaua.ecommerce.infrastructure.listeners.models.TestCategoryListenerDomainEvent;
+import com.kaua.ecommerce.infrastructure.listeners.models.ValuePayload;
+import com.kaua.ecommerce.infrastructure.outbox.OutboxEventEntity;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.eq;
+
+public class ProductEventListenerTest extends AbstractEmbeddedKafkaTest {
+
+    @MockBean
+    private SaveProductUseCase saveProductUseCase;
+
+    @MockBean
+    private ProductGateway productGateway;
+
+    @Value("${kafka.consumers.products.topics}")
+    private String productTopic;
+
+    @Test
+    void givenAValidProductCreatedEvent_whenReceive_shouldPersistProduct() throws Exception {
+        // given
+        final var aProduct = Fixture.Products.book();
+        final var aProductEvent = ProductCreatedEvent.from(aProduct);
+        final var aOutboxEvent = OutboxEventEntity.from(aProductEvent);
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.CREATE)));
+
+        final var latch = new CountDownLatch(1);
+
+        Mockito.doReturn(Optional.of(aProduct)).when(productGateway).findById(Mockito.any());
+
+        Mockito.doAnswer(t -> {
+            latch.countDown();
+            return aProduct;
+        }).when(saveProductUseCase).execute(Mockito.any());
+
+        // when
+        producer().send(new ProducerRecord<>(productTopic, aMessage));
+        producer().flush();
+
+        Assertions.assertTrue(latch.await(3, TimeUnit.MINUTES));
+
+        // then
+        Mockito.verify(saveProductUseCase, Mockito.times(1)).execute(eq(aProduct));
+    }
+
+    @Test
+    void givenAValidEventButEventTypeDoesNotMatch_whenReceive_shouldDoNothing() {
+        // given
+        final var aOutboxEntity = OutboxEventEntity.from(new
+                TestCategoryListenerDomainEvent(CategoryID.unique().getValue()));
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEntity, aOutboxEntity, aSource(), Operation.CREATE)));
+
+        // when
+        producer().send(new ProducerRecord<>(productTopic, aMessage));
+        producer().flush();
+
+        // then
+        Mockito.verify(saveProductUseCase, Mockito.times(0)).execute(Mockito.any());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductElasticsearchGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductElasticsearchGatewayTest.java
@@ -1,0 +1,59 @@
+package com.kaua.ecommerce.infrastructure.product;
+
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.domain.product.ProductImageType;
+import com.kaua.ecommerce.infrastructure.AbstractElasticsearchTest;
+import com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch.ProductElasticsearchRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ProductElasticsearchGatewayTest extends AbstractElasticsearchTest {
+
+    @Autowired
+    private ProductElasticsearchGateway productElasticsearchGateway;
+
+    @Autowired
+    private ProductElasticsearchRepository productElasticsearchRepository;
+
+    @Test
+    void givenAValidProduct_whenCallSave_shouldReturnProductSaved() {
+        final var aProduct = Fixture.Products.book();
+        aProduct.changeBannerImage(Fixture.Products.productImage(ProductImageType.BANNER));
+        aProduct.addImage(Fixture.Products.productImage(ProductImageType.GALLERY));
+
+        Assertions.assertEquals(0, this.productElasticsearchRepository.count());
+
+        final var actualProduct = this.productElasticsearchGateway.save(aProduct);
+
+        Assertions.assertEquals(1, this.productElasticsearchRepository.count());
+
+        Assertions.assertEquals(aProduct.getId().getValue(), actualProduct.getId().getValue());
+        Assertions.assertEquals(aProduct.getName(), actualProduct.getName());
+        Assertions.assertEquals(aProduct.getDescription(), actualProduct.getDescription());
+        Assertions.assertEquals(aProduct.getPrice(), actualProduct.getPrice());
+        Assertions.assertEquals(aProduct.getQuantity(), actualProduct.getQuantity());
+        Assertions.assertEquals(aProduct.getBannerImage().get().getLocation(), actualProduct.getBannerImage().get().getLocation());
+        Assertions.assertEquals(aProduct.getImages().size(), actualProduct.getImages().size());
+        Assertions.assertEquals(aProduct.getCategoryId().getValue(), actualProduct.getCategoryId().getValue());
+        Assertions.assertEquals(aProduct.getAttributes().size(), actualProduct.getAttributes().size());
+        Assertions.assertEquals(aProduct.getStatus(), actualProduct.getStatus());
+        Assertions.assertEquals(aProduct.getCreatedAt(), actualProduct.getCreatedAt());
+        Assertions.assertEquals(aProduct.getUpdatedAt(), actualProduct.getUpdatedAt());
+    }
+
+    @Test
+    void testNotImplementedMethods() {
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> productElasticsearchGateway.findAll(null));
+
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> productElasticsearchGateway.findById(null));
+
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> productElasticsearchGateway.findByIdNested(null));
+
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> productElasticsearchGateway.deleteById(null));
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductGatewayTest.java
@@ -106,9 +106,9 @@ public class ProductGatewayTest {
         Assertions.assertEquals(aProduct.getQuantity(), aPersistedProduct.getQuantity());
         Assertions.assertEquals(aProduct.getCategoryId().getValue(), aPersistedProduct.getCategoryId().getValue());
         Assertions.assertEquals(1, aPersistedProduct.getImages().size());
-        Assertions.assertEquals(aProduct.getAttributes().stream().findFirst().get().sku(), aPersistedProduct.getAttributes().stream().findFirst().get().sku());
-        Assertions.assertEquals(aProduct.getAttributes().stream().findFirst().get().color().color(), aPersistedProduct.getAttributes().stream().findFirst().get().color().color());
-        Assertions.assertEquals(aProduct.getAttributes().stream().findFirst().get().size().size(), aPersistedProduct.getAttributes().stream().findFirst().get().size().size());
+        Assertions.assertEquals(aProduct.getAttributes().stream().findFirst().get().getSku(), aPersistedProduct.getAttributes().stream().findFirst().get().getSku());
+        Assertions.assertEquals(aProduct.getAttributes().stream().findFirst().get().getColor().getColor(), aPersistedProduct.getAttributes().stream().findFirst().get().getColor().getColor());
+        Assertions.assertEquals(aProduct.getAttributes().stream().findFirst().get().getSize().getSize(), aPersistedProduct.getAttributes().stream().findFirst().get().getSize().getSize());
         Assertions.assertEquals(aProduct.getCreatedAt(), aPersistedProduct.getCreatedAt());
         Assertions.assertEquals(aProduct.getUpdatedAt(), aPersistedProduct.getUpdatedAt());
     }
@@ -131,10 +131,10 @@ public class ProductGatewayTest {
 
         Assertions.assertEquals(1, this.productColorRepository.count());
 
-        final var aPersistedProductColor = this.productGateway.findColorByName(aProductColor.color()).get();
+        final var aPersistedProductColor = this.productGateway.findColorByName(aProductColor.getColor()).get();
 
-        Assertions.assertEquals(aProductColor.id(), aPersistedProductColor.id());
-        Assertions.assertEquals(aProductColor.color(), aPersistedProductColor.color());
+        Assertions.assertEquals(aProductColor.getId(), aPersistedProductColor.getId());
+        Assertions.assertEquals(aProductColor.getColor(), aPersistedProductColor.getColor());
     }
 
     @Test

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductMediaResourceGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductMediaResourceGatewayTest.java
@@ -48,12 +48,12 @@ public class ProductMediaResourceGatewayTest {
                 this.mediaResourceGateway.storeImage(aProductId, aResource);
 
         // then
-        Assertions.assertNotNull(actualMedia.id());
-        Assertions.assertNotNull(actualMedia.location());
-        Assertions.assertEquals(aResource.resource().fileName(), actualMedia.name());
-        Assertions.assertNotNull(actualMedia.url());
+        Assertions.assertNotNull(actualMedia.getId());
+        Assertions.assertNotNull(actualMedia.getLocation());
+        Assertions.assertEquals(aResource.resource().fileName(), actualMedia.getName());
+        Assertions.assertNotNull(actualMedia.getUrl());
 
-        Assertions.assertTrue(storageService().storage().containsKey(actualMedia.location()));
+        Assertions.assertTrue(storageService().storage().containsKey(actualMedia.getLocation()));
         Assertions.assertEquals(1, storageService().storage().size());
     }
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductColorJpaRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductColorJpaRepositoryTest.java
@@ -64,8 +64,8 @@ public class ProductColorJpaRepositoryTest {
 
         final var aPersistedProductColor = this.productColorRepository.save(aEntity).toDomain();
 
-        Assertions.assertEquals(aProductColor.id(), aPersistedProductColor.id());
-        Assertions.assertEquals(aProductColor.color(), aPersistedProductColor.color());
+        Assertions.assertEquals(aProductColor.getId(), aPersistedProductColor.getId());
+        Assertions.assertEquals(aProductColor.getColor(), aPersistedProductColor.getColor());
         Assertions.assertEquals(1, this.productColorRepository.count());
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductElasticsearchRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductElasticsearchRepositoryTest.java
@@ -1,0 +1,125 @@
+package com.kaua.ecommerce.infrastructure.product.persistence;
+
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.domain.category.CategoryID;
+import com.kaua.ecommerce.domain.product.*;
+import com.kaua.ecommerce.domain.utils.IdUtils;
+import com.kaua.ecommerce.domain.utils.InstantUtils;
+import com.kaua.ecommerce.infrastructure.AbstractElasticsearchTest;
+import com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+public class ProductElasticsearchRepositoryTest extends AbstractElasticsearchTest {
+
+    @Autowired
+    private ProductElasticsearchRepository productElasticsearchRepository;
+
+    @Test
+    void givenAValidProduct_whenCallSave_shouldPersistProduct() {
+        final var aProduct = Fixture.Products.book();
+        aProduct.changeBannerImage(Fixture.Products.productImage(ProductImageType.BANNER));
+        aProduct.addImage(Fixture.Products.productImage(ProductImageType.GALLERY));
+
+        Assertions.assertEquals(0, this.productElasticsearchRepository.count());
+
+        final var actualProduct = this.productElasticsearchRepository
+                .save(ProductElasticsearchEntity.toEntity(aProduct)).toDomain();
+
+        Assertions.assertEquals(1, this.productElasticsearchRepository.count());
+
+        final var aPersistedProduct = this.productElasticsearchRepository.findById(aProduct.getId().getValue()).get();
+
+        Assertions.assertEquals(actualProduct.getId().getValue(), aPersistedProduct.getId());
+        Assertions.assertEquals(actualProduct.getName(), aPersistedProduct.getName());
+        Assertions.assertEquals(actualProduct.getDescription(), aPersistedProduct.getDescription());
+        Assertions.assertEquals(actualProduct.getPrice(), aPersistedProduct.getPrice());
+        Assertions.assertEquals(actualProduct.getQuantity(), aPersistedProduct.getQuantity());
+        Assertions.assertEquals(actualProduct.getBannerImage().get().getId(), aPersistedProduct.getBannerImage().get().getId());
+        Assertions.assertEquals(actualProduct.getBannerImage().get().getName(), aPersistedProduct.getBannerImage().get().getName());
+        Assertions.assertEquals(actualProduct.getBannerImage().get().getLocation(), aPersistedProduct.getBannerImage().get().getLocation());
+        Assertions.assertEquals(actualProduct.getBannerImage().get().getUrl(), aPersistedProduct.getBannerImage().get().getUrl());
+        Assertions.assertEquals(actualProduct.getImages().size(), aPersistedProduct.getImages().size());
+        Assertions.assertEquals(actualProduct.getCategoryId().getValue(), aPersistedProduct.getCategoryId());
+        Assertions.assertEquals(actualProduct.getAttributes().stream().findFirst().get()
+                .getSize().getId(), aPersistedProduct.getAttributes().stream().findFirst().get().getSize().getId());
+        Assertions.assertEquals(actualProduct.getAttributes().stream().findFirst().get()
+                .getColor().getId(), aPersistedProduct.getAttributes().stream().findFirst().get().getColor().getId());
+        Assertions.assertEquals(actualProduct.getAttributes().stream().findFirst().get()
+                .getSku(), aPersistedProduct.getAttributes().stream().findFirst().get().getSku());
+        Assertions.assertEquals(actualProduct.getStatus(), aPersistedProduct.getStatus());
+        Assertions.assertNotNull(aPersistedProduct.getCreatedAt());
+        Assertions.assertNotNull(aPersistedProduct.getUpdatedAt());
+    }
+
+    @Test
+    void givenAValidProductAndSetOtherValues_whenCallSave_shouldPersistProduct() {
+        final var aProduct = Fixture.Products.book();
+        aProduct.changeBannerImage(Fixture.Products.productImage(ProductImageType.BANNER));
+        aProduct.addImage(Fixture.Products.productImage(ProductImageType.GALLERY));
+
+        final var aProductImage = Fixture.Products.productImage(ProductImageType.GALLERY);
+        final var aProductImageEntity = ProductImageElasticsearchEntity.toEntity(aProductImage);
+        aProductImageEntity.setId(IdUtils.generateWithoutDash());
+        aProductImageEntity.setName("name.png");
+        aProductImageEntity.setLocation("location");
+        aProductImageEntity.setUrl("url");
+
+        final var aProductColor = ProductColor.with("Red");
+        final var aProductColorEntity = ProductColorElasticsearchEntity.toEntity(aProductColor);
+        aProductColorEntity.setId(IdUtils.generate());
+        aProductColorEntity.setColor("Blue");
+        final var aProductColorAfterSet = aProductColorEntity.toDomain();
+
+        final var aProductSize = ProductSize.with("M", 5, 0.5, 0.5, 0.5);
+        final var aProductSizeEntity = ProductSizeElasticsearchEntity.toEntity(aProductSize);
+        aProductSizeEntity.setId(IdUtils.generate());
+        aProductSizeEntity.setSize("G");
+        aProductSizeEntity.setWeight(10.0);
+        aProductSizeEntity.setHeight(1.0);
+        aProductSizeEntity.setWidth(1.0);
+        aProductSizeEntity.setDepth(1.0);
+        final var aProductSizeAfterSet = aProductSizeEntity.toDomain();
+
+        final var aEntity = ProductElasticsearchEntity.toEntity(aProduct);
+        aEntity.setId(ProductID.unique().getValue());
+        aEntity.setName("Other Name");
+        aEntity.setDescription("Other Description");
+        aEntity.setPrice(BigDecimal.valueOf(1000.0));
+        aEntity.setQuantity(10);
+        aEntity.setBannerImage(null);
+        aEntity.setCategoryId(CategoryID.unique().getValue());
+        aEntity.setStatus(ProductStatus.INACTIVE);
+        aEntity.setCreatedAt(InstantUtils.now());
+        aEntity.setUpdatedAt(InstantUtils.now());
+        aEntity.setImages(Set.of(aProductImageEntity));
+        aEntity.setAttributes(Set.of(ProductAttributesElasticsearchEntity.toEntity(
+                ProductAttributes.with(aProductColorAfterSet, aProductSizeAfterSet, "sku"))));
+
+        Assertions.assertEquals(0, this.productElasticsearchRepository.count());
+
+        final var actualProduct = this.productElasticsearchRepository
+                .save(aEntity).toDomain();
+
+        Assertions.assertEquals(1, this.productElasticsearchRepository.count());
+
+        final var aPersistedProduct = this.productElasticsearchRepository.findById(actualProduct.getId().getValue()).get();
+
+        Assertions.assertEquals(actualProduct.getId().getValue(), aPersistedProduct.getId());
+        Assertions.assertEquals(actualProduct.getName(), aPersistedProduct.getName());
+        Assertions.assertEquals(actualProduct.getDescription(), aPersistedProduct.getDescription());
+        Assertions.assertEquals(actualProduct.getPrice(), aPersistedProduct.getPrice());
+        Assertions.assertEquals(actualProduct.getQuantity(), aPersistedProduct.getQuantity());
+        Assertions.assertTrue(actualProduct.getBannerImage().isEmpty());
+        Assertions.assertEquals(actualProduct.getImages().size(), aPersistedProduct.getImages().size());
+        Assertions.assertEquals(actualProduct.getCategoryId().getValue(), aPersistedProduct.getCategoryId());
+        Assertions.assertEquals(1, actualProduct.getAttributes().size());
+        Assertions.assertEquals(actualProduct.getStatus(), aPersistedProduct.getStatus());
+        Assertions.assertNotNull(aPersistedProduct.getCreatedAt());
+        Assertions.assertNotNull(aPersistedProduct.getUpdatedAt());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductJpaRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/persistence/ProductJpaRepositoryTest.java
@@ -269,12 +269,12 @@ public class ProductJpaRepositoryTest {
         aProductSize.setDepth(1.0);
         final var aProductSizeDomain = aProductSize.toDomain();
 
-        Assertions.assertEquals(aProductSize.getId(), aProductSizeDomain.id());
-        Assertions.assertEquals(aProductSize.getSize(), aProductSizeDomain.size());
-        Assertions.assertEquals(aProductSize.getWeight(), aProductSizeDomain.weight());
-        Assertions.assertEquals(aProductSize.getHeight(), aProductSizeDomain.height());
-        Assertions.assertEquals(aProductSize.getWidth(), aProductSizeDomain.width());
-        Assertions.assertEquals(aProductSize.getDepth(), aProductSizeDomain.depth());
+        Assertions.assertEquals(aProductSize.getId(), aProductSizeDomain.getId());
+        Assertions.assertEquals(aProductSize.getSize(), aProductSizeDomain.getSize());
+        Assertions.assertEquals(aProductSize.getWeight(), aProductSizeDomain.getWeight());
+        Assertions.assertEquals(aProductSize.getHeight(), aProductSizeDomain.getHeight());
+        Assertions.assertEquals(aProductSize.getWidth(), aProductSizeDomain.getWidth());
+        Assertions.assertEquals(aProductSize.getDepth(), aProductSizeDomain.getDepth());
 
         Assertions.assertEquals(0, productRepository.count());
 
@@ -357,9 +357,9 @@ public class ProductJpaRepositoryTest {
 
         final var aProductImageDomain = aProductImage.toDomain();
 
-        Assertions.assertEquals(aProductImage.getId(), aProductImageDomain.id());
-        Assertions.assertEquals(aProductImage.getName(), aProductImageDomain.name());
-        Assertions.assertEquals(aProductImage.getLocation(), aProductImageDomain.location());
+        Assertions.assertEquals(aProductImage.getId(), aProductImageDomain.getId());
+        Assertions.assertEquals(aProductImage.getName(), aProductImageDomain.getName());
+        Assertions.assertEquals(aProductImage.getLocation(), aProductImageDomain.getLocation());
 
         Assertions.assertEquals(0, productRepository.count());
 


### PR DESCRIPTION
## Descrição

Foi adicionado a funcionalidade de processamento do evento de ```product_created``` e salvando no elasticsearch

## Mudanças Propostas

Foi adicionado a funcionalidade de processamento do evento de ```product_created``` e salvando no elasticsearch

## Testes Realizados

Testes de unidade e integração

## Cobertura de Testes

O mínimo é 95%, esta em 100%

## Problemas Conhecidos

Hoje o certo era tenta processar umas 3x a mensagem e caso não conseguisse enviar pra um DLQ, analisar exatamente qual seria a estratégia também para que evitar que eventos antigos não interfira em eventos novos (caso da category que envia o objeto inteiro)

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
