### PR TITLE
Feature/add delete product process event

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/search/remove/RemoveProductUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/search/remove/RemoveProductUseCase.java
@@ -1,0 +1,40 @@
+package com.kaua.ecommerce.application.usecases.product.search.remove;
+
+import com.kaua.ecommerce.application.UnitUseCase;
+import com.kaua.ecommerce.application.gateways.MediaResourceGateway;
+import com.kaua.ecommerce.application.gateways.ProductGateway;
+import com.kaua.ecommerce.application.gateways.SearchGateway;
+import com.kaua.ecommerce.domain.product.Product;
+
+import java.util.Objects;
+
+public class RemoveProductUseCase extends UnitUseCase<String> {
+
+    private final ProductGateway productGateway;
+    private final MediaResourceGateway mediaResourceGateway;
+    private final SearchGateway<Product> productSearchGateway;
+
+    public RemoveProductUseCase(
+            final ProductGateway productGateway,
+            final MediaResourceGateway mediaResourceGateway,
+            final SearchGateway<Product> productSearchGateway
+    ) {
+        this.productGateway = Objects.requireNonNull(productGateway);
+        this.mediaResourceGateway = Objects.requireNonNull(mediaResourceGateway);
+        this.productSearchGateway = Objects.requireNonNull(productSearchGateway);
+    }
+
+    @Override
+    public void execute(String aId) {
+        this.productGateway.findById(aId)
+                .ifPresent(aProduct -> {
+                    if (!aProduct.getImages().isEmpty()) {
+                        this.mediaResourceGateway.clearImages(aProduct.getImages());
+                    }
+
+                    aProduct.getBannerImage().ifPresent(this.mediaResourceGateway::clearImage);
+                    this.productGateway.delete(aId);
+                });
+        this.productSearchGateway.deleteById(aId);
+    }
+}

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/product/search/remove/RemoveProductUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/product/search/remove/RemoveProductUseCaseTest.java
@@ -1,0 +1,93 @@
+package com.kaua.ecommerce.application.usecases.product.search.remove;
+
+import com.kaua.ecommerce.application.UseCaseTest;
+import com.kaua.ecommerce.application.gateways.MediaResourceGateway;
+import com.kaua.ecommerce.application.gateways.ProductGateway;
+import com.kaua.ecommerce.application.gateways.SearchGateway;
+import com.kaua.ecommerce.application.usecases.product.search.save.SaveProductUseCase;
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.domain.category.CategoryID;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.product.*;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class RemoveProductUseCaseTest extends UseCaseTest {
+
+    @Mock
+    private ProductGateway productGateway;
+
+    @Mock
+    private MediaResourceGateway mediaResourceGateway;
+
+    @Mock
+    private SearchGateway<Product> productSearchGateway;
+
+    @InjectMocks
+    private RemoveProductUseCase useCase;
+
+    @Test
+    void givenAValidProductId_whenCallRemove_shouldRemoveProduct() {
+        final var aProduct = Fixture.Products.book();
+        aProduct.changeBannerImage(Fixture.Products.productImage(ProductImageType.BANNER));
+        aProduct.addImage(Fixture.Products.productImage(ProductImageType.BANNER));
+
+        Mockito.when(productGateway.findById(Mockito.any())).thenReturn(Optional.of(aProduct));
+        Mockito.doNothing().when(mediaResourceGateway).clearImages(Mockito.any());
+        Mockito.doNothing().when(mediaResourceGateway).clearImage(Mockito.any());
+        Mockito.doNothing().when(productGateway).delete(Mockito.any());
+        Mockito.doNothing().when(productSearchGateway).deleteById(Mockito.any());
+
+        this.useCase.execute(aProduct.getId().getValue());
+
+        Mockito.verify(productGateway, Mockito.times(1)).findById(Mockito.any());
+        Mockito.verify(mediaResourceGateway, Mockito.times(1)).clearImages(Mockito.any());
+        Mockito.verify(mediaResourceGateway, Mockito.times(1)).clearImage(Mockito.any());
+        Mockito.verify(productGateway, Mockito.times(1)).delete(Mockito.any());
+        Mockito.verify(productSearchGateway, Mockito.times(1)).deleteById(Mockito.any());
+    }
+
+    @Test
+    void givenAValidProductIdButNotContainsImages_whenCallRemove_shouldRemoveProduct() {
+        final var aProduct = Fixture.Products.book();
+
+        Mockito.when(productGateway.findById(Mockito.any())).thenReturn(Optional.of(aProduct));
+        Mockito.doNothing().when(productGateway).delete(Mockito.any());
+        Mockito.doNothing().when(productSearchGateway).deleteById(Mockito.any());
+
+        this.useCase.execute(aProduct.getId().getValue());
+
+        Mockito.verify(productGateway, Mockito.times(1)).findById(Mockito.any());
+        Mockito.verify(mediaResourceGateway, Mockito.times(0)).clearImages(Mockito.any());
+        Mockito.verify(mediaResourceGateway, Mockito.times(0)).clearImage(Mockito.any());
+        Mockito.verify(productGateway, Mockito.times(1)).delete(Mockito.any());
+        Mockito.verify(productSearchGateway, Mockito.times(1)).deleteById(Mockito.any());
+    }
+
+    @Test
+    void givenAnInvalidProductId_whenCallRemove_shouldBeOk() {
+        final var aProductId = "invalid-id";
+
+        Mockito.when(productGateway.findById(Mockito.any())).thenReturn(Optional.empty());
+        Mockito.doNothing().when(productSearchGateway).deleteById(Mockito.any());
+
+        this.useCase.execute(aProductId);
+
+        Mockito.verify(productGateway, Mockito.times(1)).findById(Mockito.any());
+        Mockito.verify(mediaResourceGateway, Mockito.times(0)).clearImages(Mockito.any());
+        Mockito.verify(mediaResourceGateway, Mockito.times(0)).clearImage(Mockito.any());
+        Mockito.verify(productGateway, Mockito.times(0)).delete(Mockito.any());
+        Mockito.verify(productSearchGateway, Mockito.times(1)).deleteById(Mockito.any());
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
@@ -10,6 +10,7 @@ import com.kaua.ecommerce.application.usecases.product.delete.DefaultDeleteProdu
 import com.kaua.ecommerce.application.usecases.product.delete.DeleteProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.media.upload.DefaultUploadProductImageUseCase;
 import com.kaua.ecommerce.application.usecases.product.media.upload.UploadProductImageUseCase;
+import com.kaua.ecommerce.application.usecases.product.search.remove.RemoveProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.search.save.SaveProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.update.DefaultUpdateProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.update.UpdateProductUseCase;
@@ -69,5 +70,10 @@ public class ProductUseCaseConfig {
     @Bean
     public SaveProductUseCase saveProductUseCase() {
         return new SaveProductUseCase(productSearchGateway);
+    }
+
+    @Bean
+    public RemoveProductUseCase removeProductUseCase() {
+        return new RemoveProductUseCase(productGateway, mediaResourceGateway, productSearchGateway);
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductElasticsearchGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductElasticsearchGateway.java
@@ -7,6 +7,7 @@ import com.kaua.ecommerce.domain.product.Product;
 import com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch.ProductElasticsearchEntity;
 import com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch.ProductElasticsearchRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -20,6 +21,7 @@ public class ProductElasticsearchGateway implements SearchGateway<Product> {
         this.productElasticsearchRepository = Objects.requireNonNull(productElasticsearchRepository);
     }
 
+    @Transactional
     @Override
     public Product save(Product aggregateRoot) {
         this.productElasticsearchRepository.save(ProductElasticsearchEntity.toEntity(aggregateRoot));
@@ -41,8 +43,9 @@ public class ProductElasticsearchGateway implements SearchGateway<Product> {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
+    @Transactional
     @Override
     public void deleteById(String id) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        this.productElasticsearchRepository.deleteById(id);
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductElasticsearchGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductElasticsearchGatewayTest.java
@@ -3,6 +3,7 @@ package com.kaua.ecommerce.infrastructure.product;
 import com.kaua.ecommerce.domain.Fixture;
 import com.kaua.ecommerce.domain.product.ProductImageType;
 import com.kaua.ecommerce.infrastructure.AbstractElasticsearchTest;
+import com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch.ProductElasticsearchEntity;
 import com.kaua.ecommerce.infrastructure.product.persistence.elasticsearch.ProductElasticsearchRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,21 @@ public class ProductElasticsearchGatewayTest extends AbstractElasticsearchTest {
     }
 
     @Test
+    void givenAValidProduct_whenCallDeleteById_shouldReturnProductSaved() {
+        final var aProduct = Fixture.Products.book();
+        aProduct.changeBannerImage(Fixture.Products.productImage(ProductImageType.BANNER));
+        aProduct.addImage(Fixture.Products.productImage(ProductImageType.GALLERY));
+        this.productElasticsearchRepository.save(ProductElasticsearchEntity.toEntity(aProduct));
+
+        Assertions.assertEquals(1, this.productElasticsearchRepository.count());
+
+        Assertions.assertDoesNotThrow(() -> this.productElasticsearchGateway
+                .deleteById(aProduct.getId().getValue()));
+
+        Assertions.assertEquals(0, this.productElasticsearchRepository.count());
+    }
+
+    @Test
     void testNotImplementedMethods() {
         Assertions.assertThrows(UnsupportedOperationException.class,
                 () -> productElasticsearchGateway.findAll(null));
@@ -52,8 +68,5 @@ public class ProductElasticsearchGatewayTest extends AbstractElasticsearchTest {
 
         Assertions.assertThrows(UnsupportedOperationException.class,
                 () -> productElasticsearchGateway.findByIdNested(null));
-
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> productElasticsearchGateway.deleteById(null));
     }
 }


### PR DESCRIPTION
## Descrição

Foi adicionado o processamento do evento ```product_deleted```

## Mudanças Propostas

O processamento do evento foi adicionado no commit: 9da77413d33d9e72e4351dd3c48156e59fb66fff

## Testes Realizados

Testes de unidade e integração

## Cobertura de Testes

O mínimo é 95%, está em 100%

## Problemas Conhecidos

Hoje temos o problema de que se enviarmos 2 eventos o primeiro não for processado mas o segundo sim e dai caso o segundo volte pra fila, ele sera processado gerando informações incorretas (caso do remove product ou até mesmo no category)

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
