### PR TITLE
Feature/add retry and handle old product events

### DIFF
--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/KafkaConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/KafkaConfig.java
@@ -12,6 +12,7 @@ import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.converter.StringJsonMessageConverter;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
@@ -33,7 +34,7 @@ public class KafkaConfig {
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
         configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         configProps.put(ProducerConfig.ACKS_CONFIG, "all");
 
         return new DefaultKafkaProducerFactory<>(configProps);

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/listeners/ProductEventListener.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/listeners/ProductEventListener.java
@@ -4,18 +4,28 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.kaua.ecommerce.application.gateways.ProductGateway;
 import com.kaua.ecommerce.application.usecases.product.search.remove.RemoveProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.search.save.SaveProductUseCase;
+import com.kaua.ecommerce.domain.event.DomainEvent;
 import com.kaua.ecommerce.domain.event.EventsTypes;
 import com.kaua.ecommerce.domain.product.events.ProductCreatedEvent;
 import com.kaua.ecommerce.domain.product.events.ProductDeletedEvent;
 import com.kaua.ecommerce.domain.product.events.ProductUpdatedEvent;
+import com.kaua.ecommerce.domain.utils.InstantUtils;
 import com.kaua.ecommerce.infrastructure.configurations.json.Json;
 import com.kaua.ecommerce.infrastructure.listeners.models.MessageValue;
 import com.kaua.ecommerce.infrastructure.outbox.OutboxEventEntity;
+import com.kaua.ecommerce.infrastructure.service.EventValidationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.adapter.ConsumerRecordMetadata;
+import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
@@ -29,19 +39,27 @@ public class ProductEventListener {
 
     private static final String NOT_FOUND_MESSAGE = "Product not found in database: {}";
     private static final String EVENT_RECEIVED_MESSAGE = "Product {} received from Kafka: {}";
+    private static final String PRODUCT_TOPIC = "product-topic";
+    private static final String PRODUCT_DLT_INVALID = "product-dlt-invalid";
 
     private final ProductGateway productGateway;
     private final SaveProductUseCase saveProductUseCase;
     private final RemoveProductUseCase removeProductUseCase;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final EventValidationService eventValidationService;
 
     public ProductEventListener(
             final ProductGateway productGateway,
             final SaveProductUseCase saveProductUseCase,
-            final RemoveProductUseCase removeProductUseCase
+            final RemoveProductUseCase removeProductUseCase,
+            final KafkaTemplate<String, Object> kafkaTemplate,
+            final EventValidationService eventValidationService
     ) {
         this.productGateway = Objects.requireNonNull(productGateway);
         this.saveProductUseCase = Objects.requireNonNull(saveProductUseCase);
         this.removeProductUseCase = Objects.requireNonNull(removeProductUseCase);
+        this.kafkaTemplate = Objects.requireNonNull(kafkaTemplate);
+        this.eventValidationService = Objects.requireNonNull(eventValidationService);
     }
 
     @KafkaListener(
@@ -54,39 +72,108 @@ public class ProductEventListener {
                     "auto.offset.reset=${kafka.consumers.products.auto-offset-reset}"
             }
     )
-    public void onMessage(@Payload final String payload, final Acknowledgment ack) {
-        LOG.debug("Message received from Kafka: {}", payload);
+    @RetryableTopic(
+            // backoff delay 2 seconds, multiplier 2
+            backoff = @Backoff(delay = 2000, multiplier = 2),
+            attempts = "${kafka.consumers.products.max-attempts}",
+            autoCreateTopics = "${kafka.consumers.products.auto-create-topics}",
+            dltTopicSuffix = "-retry-dlt",
+            topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
+    )
+    public void onMessage(
+            @Payload final String payload,
+            final Acknowledgment ack,
+            final ConsumerRecordMetadata metadata
+    ) {
+        LOG.atLevel(Level.INFO).log("Message received from Kafka [topic:{}] [partition:{}] [offset:{}]: {}",
+                metadata.topic(), metadata.partition(), metadata.offset(), payload);
+
         final var aOutBoxEvent = Json.readValue(payload, PRODUCT_MESSAGE).payload().after();
 
         switch (aOutBoxEvent.getEventType()) {
             case EventsTypes.PRODUCT_CREATED -> {
                 final var aProductCreated = Json.readValue(aOutBoxEvent.getData(), ProductCreatedEvent.class);
                 final var aProductId = aProductCreated.id();
-                this.productGateway.findById(aProductId)
-                        .ifPresentOrElse(aProduct -> {
-                            this.saveProductUseCase.execute(aProduct);
-                            ack.acknowledge();
-                            LOG.debug(EVENT_RECEIVED_MESSAGE, "created", aProductId);
-                        }, () -> LOG.debug(NOT_FOUND_MESSAGE, aProductId));
+
+                processCreatedAndUpdatedEvent(
+                        aProductId,
+                        ack,
+                        "created",
+                        aProductCreated,
+                        payload
+                );
             }
             case EventsTypes.PRODUCT_UPDATED -> {
                 final var aProductUpdated = Json.readValue(aOutBoxEvent.getData(), ProductUpdatedEvent.class);
                 final var aProductId = aProductUpdated.id();
-                this.productGateway.findById(aProductId)
-                        .ifPresentOrElse(aProduct -> {
-                            this.saveProductUseCase.execute(aProduct);
-                            ack.acknowledge();
-                            LOG.debug(EVENT_RECEIVED_MESSAGE, "updated", aProductId);
-                        }, () -> LOG.debug(NOT_FOUND_MESSAGE, aProductId));
+
+                processCreatedAndUpdatedEvent(
+                        aProductId,
+                        ack,
+                        "updated",
+                        aProductUpdated,
+                        payload
+                );
             }
             case EventsTypes.PRODUCT_DELETED -> {
                 final var aProductUpdated = Json.readValue(aOutBoxEvent.getData(), ProductDeletedEvent.class);
                 final var aProductId = aProductUpdated.id();
+
+                if (this.eventValidationService.isInvalid(aProductUpdated, aProductId)) {
+                    this.kafkaTemplate.send(PRODUCT_DLT_INVALID, payload);
+                    LOG.error("Product event is old, sent to DLT: {} and now: {}, payload: {}",
+                            aProductUpdated.occurredOn(), InstantUtils.now(), payload);
+                    ack.acknowledge();
+                    return;
+                }
+
                 this.removeProductUseCase.execute(aProductId);
                 ack.acknowledge();
-                LOG.debug(EVENT_RECEIVED_MESSAGE, "deleted", aProductId);
+                this.eventValidationService.invalidate(aProductUpdated.aggregateName(), aProductId);
+                LOG.info(EVENT_RECEIVED_MESSAGE, "deleted", aProductId);
             }
             default -> LOG.warn("Event type not supported: {}", aOutBoxEvent.getEventType());
         }
+    }
+
+    @DltHandler
+    public void onDltMessage(
+            @Payload String payload,
+            final Acknowledgment acknowledgment,
+            final ConsumerRecordMetadata metadata
+    ) {
+        LOG.atLevel(Level.WARN).log("Message received from Kafka at DLT [topic:{}] [partition:{}] [offset:{}]: {}",
+                metadata.topic(), metadata.partition(), metadata.offset(), payload);
+
+        final var aOutBoxEvent = Json.readValue(payload, PRODUCT_MESSAGE).payload().after();
+        final var aInstantNow = InstantUtils.now();
+
+        this.kafkaTemplate.send(PRODUCT_TOPIC, payload);
+        acknowledgment.acknowledge();
+        LOG.warn("Event sent to product topic for retry: {}, occurred on: {} and now: {}, payload: {}",
+                PRODUCT_TOPIC, aOutBoxEvent.getOccurredOn(), aInstantNow, payload);
+    }
+
+    private <T extends DomainEvent> void processCreatedAndUpdatedEvent(
+            final String aId,
+            final Acknowledgment ack,
+            final String type,
+            final T aDomainEvent,
+            final String aPayload
+    ) {
+        if (this.eventValidationService.isInvalid(aDomainEvent, aId)) {
+            this.kafkaTemplate.send(PRODUCT_DLT_INVALID, aPayload);
+            ack.acknowledge();
+            LOG.error("Product event is old, sent to DLT: {} and now: {}, payload: {}",
+                    aDomainEvent.occurredOn(), InstantUtils.now(), aPayload);
+            return;
+        }
+
+        this.productGateway.findById(aId)
+                .ifPresentOrElse(aProduct -> {
+                    this.saveProductUseCase.execute(aProduct);
+                    ack.acknowledge();
+                    LOG.info(EVENT_RECEIVED_MESSAGE, type, aId);
+                }, () -> LOG.debug(NOT_FOUND_MESSAGE, aId));
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/outbox/OutboxEventEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/outbox/OutboxEventEntity.java
@@ -1,5 +1,6 @@
 package com.kaua.ecommerce.infrastructure.outbox;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kaua.ecommerce.domain.event.DomainEvent;
 import com.kaua.ecommerce.domain.utils.IdUtils;
 import com.kaua.ecommerce.infrastructure.configurations.json.Json;
@@ -16,18 +17,23 @@ public class OutboxEventEntity {
 
     @Id
     @Column(name = "event_id", nullable = false)
+    @JsonProperty("event_id")
     private String eventId;
 
     @Column(name = "aggregate_name", nullable = false)
+    @JsonProperty("aggregate_name")
     private String aggregateName;
 
     @Column(name = "event_type", nullable = false)
+    @JsonProperty("event_type")
     private String eventType;
 
     @Column(name = "data", nullable = false)
+    @JsonProperty("data")
     private String data;
 
     @Column(name = "occurred_on", nullable = false)
+    @JsonProperty("occurred_on")
     private Instant occurredOn;
 
     public OutboxEventEntity() {

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/outbox/event/EventValidationEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/outbox/event/EventValidationEntity.java
@@ -1,0 +1,46 @@
+package com.kaua.ecommerce.infrastructure.outbox.event;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+@RedisHash(value = "event-validation")
+public class EventValidationEntity implements Serializable {
+
+    @Id
+    private String id;
+
+    private Instant occurredOn;
+
+    public EventValidationEntity() {
+    }
+
+    private EventValidationEntity(final String id, final Instant occurredOn) {
+        this.id = id;
+        this.occurredOn = occurredOn;
+    }
+
+    public static EventValidationEntity from(final String id, final Instant occurredOn) {
+        return new EventValidationEntity(id, occurredOn);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Instant getOccurredOn() {
+        return occurredOn;
+    }
+
+    public void setOccurredOn(Instant occurredOn) {
+        this.occurredOn = occurredOn;
+    }
+
+
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/outbox/event/EventValidationRepository.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/outbox/event/EventValidationRepository.java
@@ -1,0 +1,6 @@
+package com.kaua.ecommerce.infrastructure.outbox.event;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface EventValidationRepository extends CrudRepository<EventValidationEntity, String> {
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/EventValidationService.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/EventValidationService.java
@@ -1,0 +1,10 @@
+package com.kaua.ecommerce.infrastructure.service;
+
+import com.kaua.ecommerce.domain.event.DomainEvent;
+
+public interface EventValidationService {
+
+    <T extends DomainEvent> boolean isInvalid(final T event, final String payloadId);
+
+    void invalidate(final String aggregateName, final String payloadId);
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/impl/RedisEventValidationServiceImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/impl/RedisEventValidationServiceImpl.java
@@ -1,0 +1,51 @@
+package com.kaua.ecommerce.infrastructure.service.impl;
+
+import com.kaua.ecommerce.domain.event.DomainEvent;
+import com.kaua.ecommerce.infrastructure.outbox.event.EventValidationEntity;
+import com.kaua.ecommerce.infrastructure.outbox.event.EventValidationRepository;
+import com.kaua.ecommerce.infrastructure.service.EventValidationService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisEventValidationServiceImpl implements EventValidationService {
+
+    private final EventValidationRepository eventValidationRepository;
+
+    public RedisEventValidationServiceImpl(
+            final EventValidationRepository eventValidationRepository
+    ) {
+        this.eventValidationRepository = eventValidationRepository;
+    }
+
+    // TODO: aparentemente as transaction não funcionam, o certo seria usar operações atomicas
+    // mas como vamos remover isso pois vamos adicionar uma version direto no db, não vamos nos preocupar com isso
+    // o db e o elastic, manteram a version e logo quando recebermos um evento, vamos verificar se a version é a mesma
+    // vamos verficar no elastic se a versão é a no futuro, se for, ignoramos o evento
+    @Override
+    public <T extends DomainEvent> boolean isInvalid(final T event, final String payloadId) {
+        final var aEventValidationId = event.aggregateName().concat("-").concat(payloadId);
+
+        final var aEventValidation = this.eventValidationRepository.findById(aEventValidationId);
+
+        if (aEventValidation.isEmpty()) {
+            final var aNewEventValidation = EventValidationEntity
+                    .from(aEventValidationId, event.occurredOn());
+            this.eventValidationRepository.save(aNewEventValidation);
+            return false;
+        }
+
+        if (aEventValidation.get().getOccurredOn().isBefore(event.occurredOn())) {
+            aEventValidation.get().setOccurredOn(event.occurredOn());
+            this.eventValidationRepository.save(aEventValidation.get());
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void invalidate(String aggregateName, String payloadId) {
+        final var aEventValidationId = aggregateName.concat("-").concat(payloadId);
+        this.eventValidationRepository.deleteById(aEventValidationId);
+    }
+}

--- a/infrastructure/src/main/resources/application-development.yml
+++ b/infrastructure/src/main/resources/application-development.yml
@@ -15,6 +15,12 @@ elasticsearch:
   username: elastic
   password: elastic
 
+kafka:
+  consumers:
+    products:
+      auto-create-topics: true
+
+
 logging:
   level:
     com.kaua.ecommerce.infrastructure: DEBUG

--- a/infrastructure/src/main/resources/application-production.yml
+++ b/infrastructure/src/main/resources/application-production.yml
@@ -18,3 +18,8 @@ elasticsearch:
   host: ${ELASTICSEARCH_HOST:http://localhost:9200}
   username: ${ELASTICSEARCH_USERNAME:elastic}
   password: ${ELASTICSEARCH_PASSWORD:elastic}
+
+kafka:
+  consumers:
+    products:
+      auto-create-topics: true

--- a/infrastructure/src/main/resources/application-test-integration-kafka.yml
+++ b/infrastructure/src/main/resources/application-test-integration-kafka.yml
@@ -7,6 +7,11 @@ elasticsearch:
   username: elastic
   password: elastic
 
+kafka:
+  consumers:
+    products:
+      auto-create-topics: true
+
 spring:
   autoconfigure:
     exclude:

--- a/infrastructure/src/main/resources/application-test-integration.yml
+++ b/infrastructure/src/main/resources/application-test-integration.yml
@@ -7,6 +7,11 @@ elasticsearch:
   username: elastic
   password: elastic
 
+kafka:
+  consumers:
+    products:
+      auto-create-topics: false
+
 spring:
   autoconfigure:
     exclude:

--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -46,6 +46,8 @@ kafka:
       id: kafka-listener-products
       topics: product-topic
       group-id: products-group
+      max-attempts: 4
+      auto-create-topics: false
 
 server:
   port: 8080

--- a/infrastructure/src/test/java/com/kaua/ecommerce/application/customer/update/address/UpdateCustomerAddressUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/application/customer/update/address/UpdateCustomerAddressUseCaseIT.java
@@ -1,5 +1,6 @@
 package com.kaua.ecommerce.application.customer.update.address;
 
+import com.kaua.ecommerce.application.adapters.responses.AddressResponse;
 import com.kaua.ecommerce.application.usecases.customer.update.address.UpdateCustomerAddressCommand;
 import com.kaua.ecommerce.application.usecases.customer.update.address.UpdateCustomerAddressUseCase;
 import com.kaua.ecommerce.config.CacheTestConfiguration;
@@ -8,13 +9,18 @@ import com.kaua.ecommerce.domain.customer.Customer;
 import com.kaua.ecommerce.domain.exceptions.NotFoundException;
 import com.kaua.ecommerce.domain.utils.IdUtils;
 import com.kaua.ecommerce.infrastructure.CacheGatewayTest;
+import com.kaua.ecommerce.infrastructure.adapters.AddressAdapterImpl;
 import com.kaua.ecommerce.infrastructure.customer.address.persistence.AddressJpaRepository;
 import com.kaua.ecommerce.infrastructure.customer.persistence.CustomerCacheRepository;
 import com.kaua.ecommerce.infrastructure.customer.persistence.CustomerJpaEntity;
 import com.kaua.ecommerce.infrastructure.customer.persistence.CustomerJpaRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
 
 @CacheGatewayTest
 public class UpdateCustomerAddressUseCaseIT extends CacheTestConfiguration {
@@ -30,6 +36,9 @@ public class UpdateCustomerAddressUseCaseIT extends CacheTestConfiguration {
 
     @Autowired
     private AddressJpaRepository addressRepository;
+
+    @MockBean
+    private AddressAdapterImpl addressAdapter;
 
     @Test
     void givenAValidValues_whenCallsUpdateCustomerAddress_shouldReturnAccountId() {
@@ -47,6 +56,10 @@ public class UpdateCustomerAddressUseCaseIT extends CacheTestConfiguration {
 
         final var aCommand = UpdateCustomerAddressCommand
                 .with(aAccountId, aStreet, aNumber, aComplement, aDistrict, aCity, aState, aZipCode);
+
+        Mockito.when(this.addressAdapter.findAddressByZipCode(aZipCode))
+                .thenReturn(Optional
+                        .of(new AddressResponse(aZipCode, aStreet, aComplement, aDistrict, aCity, aState)));
 
         final var aResult = this.updateCustomerAddressUseCase.execute(aCommand).getRight();
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/application/customer/update/address/UpdateCustomerAddressUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/application/customer/update/address/UpdateCustomerAddressUseCaseIT.java
@@ -9,7 +9,7 @@ import com.kaua.ecommerce.domain.customer.Customer;
 import com.kaua.ecommerce.domain.exceptions.NotFoundException;
 import com.kaua.ecommerce.domain.utils.IdUtils;
 import com.kaua.ecommerce.infrastructure.CacheGatewayTest;
-import com.kaua.ecommerce.infrastructure.adapters.AddressAdapterImpl;
+import com.kaua.ecommerce.infrastructure.api.ViaCepClient;
 import com.kaua.ecommerce.infrastructure.customer.address.persistence.AddressJpaRepository;
 import com.kaua.ecommerce.infrastructure.customer.persistence.CustomerCacheRepository;
 import com.kaua.ecommerce.infrastructure.customer.persistence.CustomerJpaEntity;
@@ -19,8 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-import java.util.Optional;
 
 @CacheGatewayTest
 public class UpdateCustomerAddressUseCaseIT extends CacheTestConfiguration {
@@ -38,7 +36,7 @@ public class UpdateCustomerAddressUseCaseIT extends CacheTestConfiguration {
     private AddressJpaRepository addressRepository;
 
     @MockBean
-    private AddressAdapterImpl addressAdapter;
+    private ViaCepClient viaCepClient;
 
     @Test
     void givenAValidValues_whenCallsUpdateCustomerAddress_shouldReturnAccountId() {
@@ -57,9 +55,8 @@ public class UpdateCustomerAddressUseCaseIT extends CacheTestConfiguration {
         final var aCommand = UpdateCustomerAddressCommand
                 .with(aAccountId, aStreet, aNumber, aComplement, aDistrict, aCity, aState, aZipCode);
 
-        Mockito.when(this.addressAdapter.findAddressByZipCode(aZipCode))
-                .thenReturn(Optional
-                        .of(new AddressResponse(aZipCode, aStreet, aComplement, aDistrict, aCity, aState)));
+        Mockito.when(this.viaCepClient.getAddressByZipCode(aZipCode))
+                .thenReturn(new AddressResponse(aZipCode, aStreet, aComplement, aDistrict, aCity, aState));
 
         final var aResult = this.updateCustomerAddressUseCase.execute(aCommand).getRight();
 
@@ -134,6 +131,16 @@ public class UpdateCustomerAddressUseCaseIT extends CacheTestConfiguration {
 
         final var aCommand = UpdateCustomerAddressCommand
                 .with(aAccountId, aStreet, aNumber, aComplement, aDistrict, aCity, aState, aZipCode);
+
+        Mockito.when(this.viaCepClient.getAddressByZipCode(aZipCode))
+                .thenReturn(new AddressResponse(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                ));
 
         final var aResult = this.updateCustomerAddressUseCase.execute(aCommand).getLeft();
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/config/CacheCleanUpExtension.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/config/CacheCleanUpExtension.java
@@ -2,6 +2,7 @@ package com.kaua.ecommerce.config;
 
 import com.kaua.ecommerce.infrastructure.customer.address.persistence.AddressCacheRepository;
 import com.kaua.ecommerce.infrastructure.customer.persistence.CustomerCacheRepository;
+import com.kaua.ecommerce.infrastructure.outbox.event.EventValidationRepository;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.data.repository.CrudRepository;
@@ -18,7 +19,8 @@ public class CacheCleanUpExtension implements BeforeEachCallback {
 
         cleanUp(List.of(
                 appContext.getBean(AddressCacheRepository.class),
-                appContext.getBean(CustomerCacheRepository.class)
+                appContext.getBean(CustomerCacheRepository.class),
+                appContext.getBean(EventValidationRepository.class)
         ));
     }
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/CacheGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/CacheGatewayTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ import java.lang.annotation.*;
 @EnableAutoConfiguration(exclude = ElasticsearchRepositoriesAutoConfiguration.class)
 @SpringBootTest(classes = { Main.class, AmqpTestConfiguration.class, IntegrationTestConfiguration.class })
 @ExtendWith({ CacheCleanUpExtension.class, JpaCleanUpExtension.class })
+@DirtiesContext
 @Tag("integrationTest")
 public @interface CacheGatewayTest {
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/adapters/AddressAdapterImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/adapters/AddressAdapterImplTest.java
@@ -2,12 +2,18 @@ package com.kaua.ecommerce.infrastructure.adapters;
 
 import com.kaua.ecommerce.application.adapters.responses.AddressResponse;
 import com.kaua.ecommerce.infrastructure.IntegrationTest;
+import com.kaua.ecommerce.infrastructure.api.ViaCepClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @IntegrationTest
 public class AddressAdapterImplTest {
+
+    @MockBean
+    private ViaCepClient viaCepClient;
 
     @Autowired
     private AddressAdapterImpl addressAdapter;
@@ -15,6 +21,9 @@ public class AddressAdapterImplTest {
     @Test
     void givenAValidZipCode_whenCallFindAddressByZipCode_shouldReturnAddressResponse() {
         final var aZipCode = "01153000";
+
+        Mockito.when(viaCepClient.getAddressByZipCode(aZipCode))
+                .thenReturn(getAddressResponse());
 
         final var actual = addressAdapter.findAddressByZipCode(aZipCode);
 
@@ -24,6 +33,16 @@ public class AddressAdapterImplTest {
     @Test
     void givenAnInvalidZipCode_whenCallFindAddressByZipCode_shouldReturnEmpty() {
         final var aZipCode = "01153001";
+
+        Mockito.when(viaCepClient.getAddressByZipCode(aZipCode))
+                .thenReturn(new AddressResponse(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                ));
 
         final var actual = addressAdapter.findAddressByZipCode(aZipCode);
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/CategoryEventListenerTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/CategoryEventListenerTest.java
@@ -11,7 +11,7 @@ import com.kaua.ecommerce.infrastructure.AbstractEmbeddedKafkaTest;
 import com.kaua.ecommerce.infrastructure.configurations.json.Json;
 import com.kaua.ecommerce.infrastructure.listeners.models.MessageValue;
 import com.kaua.ecommerce.infrastructure.listeners.models.Operation;
-import com.kaua.ecommerce.infrastructure.listeners.models.TestCategoryListenerDomainEvent;
+import com.kaua.ecommerce.infrastructure.listeners.models.TestListenerDomainEvent;
 import com.kaua.ecommerce.infrastructure.listeners.models.ValuePayload;
 import com.kaua.ecommerce.infrastructure.outbox.OutboxEventEntity;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -120,7 +120,7 @@ public class CategoryEventListenerTest extends AbstractEmbeddedKafkaTest {
     void givenAValidEventButEventTypeDoesNotMatch_whenReceive_shouldDoNothing() {
         // given
         final var aOutboxEntity = OutboxEventEntity.from(new
-                TestCategoryListenerDomainEvent(CategoryID.unique().getValue()));
+                TestListenerDomainEvent(CategoryID.unique().getValue()));
         final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEntity, aOutboxEntity, aSource(), Operation.CREATE)));
 
         // when

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/ProductEventListenerTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/ProductEventListenerTest.java
@@ -4,7 +4,7 @@ import com.kaua.ecommerce.application.gateways.ProductGateway;
 import com.kaua.ecommerce.application.usecases.product.search.remove.RemoveProductUseCase;
 import com.kaua.ecommerce.application.usecases.product.search.save.SaveProductUseCase;
 import com.kaua.ecommerce.domain.Fixture;
-import com.kaua.ecommerce.domain.category.CategoryID;
+import com.kaua.ecommerce.domain.product.ProductID;
 import com.kaua.ecommerce.domain.product.events.ProductCreatedEvent;
 import com.kaua.ecommerce.domain.product.events.ProductDeletedEvent;
 import com.kaua.ecommerce.domain.product.events.ProductUpdatedEvent;
@@ -12,15 +12,27 @@ import com.kaua.ecommerce.infrastructure.AbstractEmbeddedKafkaTest;
 import com.kaua.ecommerce.infrastructure.configurations.json.Json;
 import com.kaua.ecommerce.infrastructure.listeners.models.MessageValue;
 import com.kaua.ecommerce.infrastructure.listeners.models.Operation;
-import com.kaua.ecommerce.infrastructure.listeners.models.TestCategoryListenerDomainEvent;
+import com.kaua.ecommerce.infrastructure.listeners.models.TestListenerDomainEvent;
 import com.kaua.ecommerce.infrastructure.listeners.models.ValuePayload;
 import com.kaua.ecommerce.infrastructure.outbox.OutboxEventEntity;
+import com.kaua.ecommerce.infrastructure.outbox.event.EventValidationRepository;
+import com.kaua.ecommerce.infrastructure.service.EventValidationService;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.adapter.ConsumerRecordMetadata;
+import org.springframework.kafka.support.Acknowledgment;
 
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -39,8 +51,66 @@ public class ProductEventListenerTest extends AbstractEmbeddedKafkaTest {
     @MockBean
     private RemoveProductUseCase removeProductUseCase;
 
+    @MockBean
+    private EventValidationService eventValidationService;
+
+    @SpyBean
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @SpyBean
+    private ProductEventListener productEventListener;
+
     @Value("${kafka.consumers.products.topics}")
     private String productTopic;
+
+    @Captor
+    private ArgumentCaptor<ConsumerRecordMetadata> metadata;
+
+    @Test
+    void givenAValidProductDeletedEvent_whenReceiveThrowsExceptionAndSendToDLT_shouldNotDeleteProduct() throws InterruptedException {
+        final var expectedMaxAttempts = 4;
+        final var expectedMaxDltAttempts = 1;
+        final var expectedMainTopic = "product-topic";
+        final var expectedRetry0Topic = "product-topic-retry-0";
+        final var expectedRetry1Topic = "product-topic-retry-1";
+        final var expectedRetry2Topic = "product-topic-retry-2";
+        final var expectedDltTopic = "product-topic-retry-dlt";
+
+        final var aProduct = Fixture.Products.book();
+        final var aProductEvent = ProductDeletedEvent.from(aProduct);
+        final var aOutboxEvent = OutboxEventEntity.from(aProductEvent);
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.DELETE)));
+
+        final var latch = new CountDownLatch(5);
+
+        Mockito.doAnswer(t -> {
+            latch.countDown();
+            throw new RuntimeException("Error on remove product use case");
+        }).when(removeProductUseCase).execute(Mockito.any());
+
+        Mockito.doAnswer(t -> {
+            latch.countDown();
+            return null;
+        }).when(productEventListener).onDltMessage(Mockito.any(), Mockito.any(), Mockito.any());
+
+        producer().send(new ProducerRecord<>(productTopic, aMessage));
+        producer().flush();
+
+        Assertions.assertTrue(latch.await(3, TimeUnit.MINUTES));
+
+        Mockito.verify(productEventListener, Mockito.times(expectedMaxAttempts)).onMessage(eq(aMessage), Mockito.any(), metadata.capture());
+
+        final var allMetas = metadata.getAllValues();
+        Assertions.assertEquals(expectedMainTopic, allMetas.get(0).topic());
+        Assertions.assertEquals(expectedRetry0Topic, allMetas.get(1).topic());
+        Assertions.assertEquals(expectedRetry1Topic, allMetas.get(2).topic());
+        Assertions.assertEquals(expectedRetry2Topic, allMetas.get(3).topic());
+
+        Mockito.verify(productEventListener, Mockito.times(expectedMaxDltAttempts)).onDltMessage(eq(aMessage), Mockito.any(), metadata.capture());
+
+        Assertions.assertEquals(expectedDltTopic, metadata.getValue().topic());
+    }
 
     @Test
     void givenAValidProductCreatedEvent_whenReceive_shouldPersistProduct() throws Exception {
@@ -71,6 +141,41 @@ public class ProductEventListenerTest extends AbstractEmbeddedKafkaTest {
     }
 
     @Test
+    void givenAnInvalidProductCreatedEvent_whenReceiveAsOccurredOnIsBefore_shouldNotProcessAndMarkAck() throws Exception {
+        // given
+        final var aProduct = Fixture.Products.book();
+        final var aProductEvent = ProductCreatedEvent.from(aProduct);
+        final var aOutboxEvent = OutboxEventEntity.from(aProductEvent);
+        aOutboxEvent.setOccurredOn(aOutboxEvent.getOccurredOn()
+                .minus(1, TimeUnit.DAYS.toChronoUnit()));
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.CREATE)));
+
+        final var latch = new CountDownLatch(1);
+
+        Mockito.when(eventValidationService.isInvalid(aProductEvent, aProduct.getId().getValue()))
+                .thenAnswer(t -> {
+                    latch.countDown();
+                    return true;
+                });
+
+        // when
+        producer().send(new ProducerRecord<>(productTopic, aMessage));
+        producer().flush();
+
+        Assertions.assertTrue(latch.await(3, TimeUnit.MINUTES));
+
+        // then
+        Mockito.verify(productGateway, Mockito.times(0)).findById(Mockito.any());
+        Mockito.verify(saveProductUseCase, Mockito.times(0)).execute(eq(aProduct));
+        Mockito.verify(removeProductUseCase, Mockito.times(0)).execute(Mockito.any());
+        Mockito.verify(productEventListener, Mockito.times(1))
+                .onMessage(eq(aMessage), Mockito.any(), Mockito.any());
+        Mockito.verify(eventValidationService, Mockito.times(1))
+                .isInvalid(aProductEvent, aProduct.getId().getValue());
+    }
+
+    @Test
     void givenAValidProductUpdatedEvent_whenReceive_shouldUpdateProduct() throws Exception {
         // given
         final var aProduct = Fixture.Products.book();
@@ -95,7 +200,43 @@ public class ProductEventListenerTest extends AbstractEmbeddedKafkaTest {
         Assertions.assertTrue(latch.await(3, TimeUnit.MINUTES));
 
         // then
+        Mockito.verify(productGateway, Mockito.times(1)).findById(Mockito.any());
         Mockito.verify(saveProductUseCase, Mockito.times(1)).execute(eq(aProduct));
+    }
+
+    @Test
+    void givenAnInvalidProductUpdatedEvent_whenReceiveAsOccurredOnIsBefore_shouldNotProcessAndMarkAck() throws Exception {
+        // given
+        final var aProduct = Fixture.Products.book();
+        final var aProductEvent = ProductUpdatedEvent.from(aProduct);
+        final var aOutboxEvent = OutboxEventEntity.from(aProductEvent);
+        aOutboxEvent.setOccurredOn(aOutboxEvent.getOccurredOn()
+                .minus(1, TimeUnit.DAYS.toChronoUnit()));
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.UPDATE)));
+
+        final var latch = new CountDownLatch(1);
+
+        Mockito.when(eventValidationService.isInvalid(aProductEvent, aProduct.getId().getValue()))
+                .thenAnswer(t -> {
+                    latch.countDown();
+                    return true;
+                });
+
+        // when
+        producer().send(new ProducerRecord<>(productTopic, aMessage));
+        producer().flush();
+
+        Assertions.assertTrue(latch.await(3, TimeUnit.MINUTES));
+
+        // then
+        Mockito.verify(productGateway, Mockito.times(0)).findById(Mockito.any());
+        Mockito.verify(saveProductUseCase, Mockito.times(0)).execute(eq(aProduct));
+        Mockito.verify(removeProductUseCase, Mockito.times(0)).execute(Mockito.any());
+        Mockito.verify(productEventListener, Mockito.times(1))
+                .onMessage(eq(aMessage), Mockito.any(), Mockito.any());
+        Mockito.verify(eventValidationService, Mockito.times(1))
+                .isInvalid(aProductEvent, aProduct.getId().getValue());
     }
 
     @Test
@@ -121,14 +262,46 @@ public class ProductEventListenerTest extends AbstractEmbeddedKafkaTest {
         Assertions.assertTrue(latch.await(3, TimeUnit.MINUTES));
 
         // then
-        Mockito.verify(removeProductUseCase, Mockito.times(1)).execute(eq(aProduct.getId().getValue()));
+        Mockito.verify(removeProductUseCase, Mockito.times(1)).execute(aProduct.getId().getValue());
+    }
+
+    @Test
+    void givenAnInvalidProductDeletedEventOccurredIsOld_whenReceiveButNotProcessThisSendDLT_shouldNotProcessProductDeletedEvent() throws InterruptedException {
+        // given
+        final var aProduct = Fixture.Products.book();
+        final var aProductEvent = ProductDeletedEvent.from(aProduct);
+        final var aOutboxEvent = OutboxEventEntity.from(aProductEvent);
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.DELETE)));
+
+        final var latch = new CountDownLatch(1);
+
+        Mockito.when(eventValidationService.isInvalid(aProductEvent, aProduct.getId().getValue()))
+                .thenAnswer(t -> {
+                    latch.countDown();
+                    return true;
+                });
+
+        // when
+        producer().send(new ProducerRecord<>(productTopic, aMessage));
+        producer().flush();
+
+        Assertions.assertTrue(latch.await(3, TimeUnit.MINUTES));
+
+        // then
+        Mockito.verify(eventValidationService, Mockito.times(1))
+                .isInvalid(aProductEvent, aProduct.getId().getValue());
+        Mockito.verify(kafkaTemplate, Mockito.times(1))
+                .send(eq("product-dlt-invalid"), eq(aMessage));
+
+        Mockito.verify(removeProductUseCase, Mockito.times(0)).execute(Mockito.any());
     }
 
     @Test
     void givenAValidEventButEventTypeDoesNotMatch_whenReceive_shouldDoNothing() {
         // given
         final var aOutboxEntity = OutboxEventEntity.from(new
-                TestCategoryListenerDomainEvent(CategoryID.unique().getValue()));
+                TestListenerDomainEvent(ProductID.unique().getValue()));
         final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEntity, aOutboxEntity, aSource(), Operation.CREATE)));
 
         // when
@@ -136,7 +309,9 @@ public class ProductEventListenerTest extends AbstractEmbeddedKafkaTest {
         producer().flush();
 
         // then
+        Mockito.verify(productGateway, Mockito.times(0)).findById(Mockito.any());
         Mockito.verify(saveProductUseCase, Mockito.times(0)).execute(Mockito.any());
+        Mockito.verify(removeProductUseCase, Mockito.times(0)).execute(Mockito.any());
     }
 
     @Test
@@ -151,8 +326,8 @@ public class ProductEventListenerTest extends AbstractEmbeddedKafkaTest {
         Mockito.doReturn(Optional.empty()).when(productGateway).findById(Mockito.any());
 
         // when
-        final var aProductEventListener = new ProductEventListener(productGateway, saveProductUseCase, removeProductUseCase);
-        aProductEventListener.onMessage(aMessage, null);
+        final var aProductEventListener = new ProductEventListener(productGateway, saveProductUseCase, removeProductUseCase, kafkaTemplate, eventValidationService);
+        aProductEventListener.onMessage(aMessage, null, buildMetadata());
 
         // then
         Mockito.verify(saveProductUseCase, Mockito.times(0)).execute(Mockito.any());
@@ -170,10 +345,82 @@ public class ProductEventListenerTest extends AbstractEmbeddedKafkaTest {
         Mockito.doReturn(Optional.empty()).when(productGateway).findById(Mockito.any());
 
         // when
-        final var aProductEventListener = new ProductEventListener(productGateway, saveProductUseCase, removeProductUseCase);
-        aProductEventListener.onMessage(aMessage, null);
+        final var aProductEventListener = new ProductEventListener(productGateway, saveProductUseCase, removeProductUseCase, kafkaTemplate, eventValidationService);
+        aProductEventListener.onMessage(aMessage, null, buildMetadata());
 
         // then
         Mockito.verify(saveProductUseCase, Mockito.times(0)).execute(Mockito.any());
+        Mockito.verify(removeProductUseCase, Mockito.times(0)).execute(Mockito.any());
+    }
+
+    @Test
+    void givenAValidProductUpdatedEvent_whenReceiveInErrorDLTButNotProcessThis_shouldNotProcessProductUpdatedEvent() {
+        final var mockMetadata = Mockito.mock(ConsumerRecordMetadata.class);
+        final var mockAcknowledgment = Mockito.mock(Acknowledgment.class);
+
+        // given
+        final var aProduct = Fixture.Products.book();
+        final var aProductEvent = ProductUpdatedEvent.from(aProduct);
+        final var aOutboxEvent = OutboxEventEntity.from(aProductEvent);
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.UPDATE)));
+
+        // when
+        Mockito.when(mockMetadata.topic()).thenReturn("product-topic");
+        Mockito.when(mockMetadata.partition()).thenReturn(1);
+        Mockito.when(mockMetadata.offset()).thenReturn(1L);
+        Mockito.when(mockMetadata.timestampType()).thenReturn(TimestampType.CREATE_TIME);
+        Mockito.when(mockMetadata.timestamp()).thenReturn(1L);
+        Mockito.doNothing().when(mockAcknowledgment).acknowledge();
+
+        final var aProductEventListener = new ProductEventListener(productGateway, saveProductUseCase, removeProductUseCase, kafkaTemplate, eventValidationService);
+        aProductEventListener.onDltMessage(aMessage, mockAcknowledgment, mockMetadata);
+
+        // then
+        Mockito.verify(productGateway, Mockito.times(0)).findById(Mockito.any());
+        Mockito.verify(saveProductUseCase, Mockito.times(0)).execute(Mockito.any());
+        Mockito.verify(removeProductUseCase, Mockito.times(0)).execute(Mockito.any());
+    }
+
+    @Test
+    void givenAnInvalidProductUpdatedEventOccurredIsOld_whenReceiveButNotProcessThisSendDLT_shouldNotProcessProductUpdatedEvent() throws InterruptedException {
+        // given
+        final var aProduct = Fixture.Products.book();
+        final var aProductEvent = ProductUpdatedEvent.from(aProduct);
+        final var aOutboxEvent = OutboxEventEntity.from(aProductEvent);
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.UPDATE)));
+
+        final var latch = new CountDownLatch(1);
+
+        Mockito.doReturn(Optional.of(aProduct)).when(productGateway).findById(Mockito.any());
+
+        Mockito.when(eventValidationService.isInvalid(aProductEvent, aProduct.getId().getValue()))
+                .thenAnswer(t -> {
+                    latch.countDown();
+                    return true;
+                });
+
+        // when
+        producer().send(new ProducerRecord<>(productTopic, aMessage));
+        producer().flush();
+
+        Assertions.assertTrue(latch.await(3, TimeUnit.MINUTES));
+
+        // then
+        Mockito.verify(eventValidationService, Mockito.times(1))
+                .isInvalid(aProductEvent, aProduct.getId().getValue());
+        Mockito.verify(kafkaTemplate, Mockito.times(1))
+                .send(eq("product-dlt-invalid"), eq(aMessage));
+
+        Mockito.verify(productGateway, Mockito.times(0)).findById(Mockito.any());
+        Mockito.verify(saveProductUseCase, Mockito.times(0)).execute(Mockito.any());
+    }
+
+    private ConsumerRecordMetadata buildMetadata() {
+        return new ConsumerRecordMetadata(
+                new RecordMetadata(new TopicPartition("product-topic", 1), 0, 1, 1, 1, 1),
+                TimestampType.CREATE_TIME
+        );
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/models/TestListenerDomainEvent.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/models/TestListenerDomainEvent.java
@@ -1,6 +1,7 @@
 package com.kaua.ecommerce.infrastructure.listeners.models;
 
 import com.kaua.ecommerce.domain.event.DomainEvent;
+import com.kaua.ecommerce.domain.utils.InstantUtils;
 
 import java.time.Instant;
 
@@ -12,6 +13,6 @@ public record TestListenerDomainEvent(
 ) implements DomainEvent {
 
     public TestListenerDomainEvent(String id) {
-        this(id, "test", "test-created", Instant.now());
+        this(id, "test", "test-created", InstantUtils.now());
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/models/TestListenerDomainEvent.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/models/TestListenerDomainEvent.java
@@ -4,14 +4,14 @@ import com.kaua.ecommerce.domain.event.DomainEvent;
 
 import java.time.Instant;
 
-public record TestCategoryListenerDomainEvent(
+public record TestListenerDomainEvent(
         String id,
         String aggregateName,
         String eventType,
         Instant occurredOn
 ) implements DomainEvent {
 
-    public TestCategoryListenerDomainEvent(String id) {
+    public TestListenerDomainEvent(String id) {
         this(id, "test", "test-created", Instant.now());
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/service/impl/RedisEventValidationServiceImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/service/impl/RedisEventValidationServiceImplTest.java
@@ -1,0 +1,111 @@
+package com.kaua.ecommerce.infrastructure.service.impl;
+
+import com.kaua.ecommerce.config.CacheTestConfiguration;
+import com.kaua.ecommerce.domain.utils.IdUtils;
+import com.kaua.ecommerce.infrastructure.CacheGatewayTest;
+import com.kaua.ecommerce.infrastructure.listeners.models.TestListenerDomainEvent;
+import com.kaua.ecommerce.infrastructure.outbox.event.EventValidationEntity;
+import com.kaua.ecommerce.infrastructure.outbox.event.EventValidationRepository;
+import com.kaua.ecommerce.infrastructure.service.EventValidationService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.temporal.ChronoUnit;
+
+@CacheGatewayTest
+public class RedisEventValidationServiceImplTest extends CacheTestConfiguration {
+
+    @Autowired
+    private EventValidationRepository eventValidationRepository;
+
+    @Autowired
+    private EventValidationService eventValidationService;
+
+    @Test
+    void givenFirstEvent_whenIsInvalid_thenShouldReturnFalse() {
+        // given
+        final var aDomainEvent = new TestListenerDomainEvent(IdUtils.generate());
+        final var aPayloadId = aDomainEvent.id();
+
+        // when
+        Assertions.assertEquals(0, this.eventValidationRepository.count());
+
+        final var aResult = this.eventValidationService.isInvalid(aDomainEvent, aPayloadId);
+
+        // then
+        Assertions.assertEquals(1, this.eventValidationRepository.count());
+        Assertions.assertFalse(aResult);
+    }
+
+    @Test
+    void givenEventAndContainsOldEventSaved_whenIsInvalid_thenShouldReturnFalse() {
+        // given
+        final var aDomainEvent = new TestListenerDomainEvent(IdUtils.generate());
+        final var aPayloadId = aDomainEvent.id();
+
+        this.eventValidationRepository.save(
+                EventValidationEntity.from(aDomainEvent.aggregateName().concat("-")
+                                .concat(aPayloadId),
+                        aDomainEvent.occurredOn().minus(1, ChronoUnit.DAYS)));
+
+        // when
+        Assertions.assertEquals(1, this.eventValidationRepository.count());
+        final var aResult = this.eventValidationService.isInvalid(aDomainEvent, aPayloadId);
+
+        // then
+        Assertions.assertFalse(aResult);
+
+        Assertions.assertEquals(aDomainEvent.occurredOn(), this.eventValidationRepository.findById(
+                aDomainEvent.aggregateName().concat("-").concat(aPayloadId)).get().getOccurredOn());
+    }
+
+    @Test
+    void givenEventAndEventStoredIs7DaysInFuture_whenIsInvalid_thenShouldReturnFalse() {
+        // given
+        final var aDomainEvent = new TestListenerDomainEvent(IdUtils.generate());
+        final var aPayloadId = aDomainEvent.id();
+
+        final var aEntity = EventValidationEntity.from(
+                aDomainEvent.aggregateName().concat("-").concat(aPayloadId),
+                aDomainEvent.occurredOn().plus(1, ChronoUnit.DAYS)
+        );
+        aEntity.setId(aDomainEvent.aggregateName().concat("-").concat(aPayloadId));
+        aEntity.setOccurredOn(aDomainEvent.occurredOn().plus(7, ChronoUnit.DAYS));
+
+        this.eventValidationRepository.save(aEntity);
+
+        // when
+        Assertions.assertEquals(1, this.eventValidationRepository.count());
+
+        final var aResult = this.eventValidationService.isInvalid(aDomainEvent, aPayloadId);
+
+        // then
+        Assertions.assertEquals(1, this.eventValidationRepository.count());
+        Assertions.assertTrue(aResult);
+        Assertions.assertEquals(aEntity.getId(), aDomainEvent.aggregateName()
+                .concat("-").concat(aPayloadId));
+    }
+
+    @Test
+    void givenAggregateNameAndPayloadId_whenInvalidate_thenShouldRemoveEventValidation() {
+        // given
+        final var aDomainEvent = new TestListenerDomainEvent(IdUtils.generate());
+        final var aPayloadId = aDomainEvent.id();
+
+        final var aPayloadIdWithAggregate = aDomainEvent.aggregateName().concat("-").concat(aPayloadId);
+
+        this.eventValidationRepository.save(
+                EventValidationEntity.from(aDomainEvent.aggregateName().concat("-")
+                                .concat(aPayloadId),
+                        aDomainEvent.occurredOn().plus(1, ChronoUnit.DAYS)));
+
+        // when
+        Assertions.assertEquals(1, this.eventValidationRepository.count());
+
+        this.eventValidationService.invalidate(aDomainEvent.aggregateName(), aPayloadId);
+
+        // then
+        Assertions.assertEquals(0, this.eventValidationRepository.count());
+    }
+}


### PR DESCRIPTION
## Descrição

Foi adicionado a parte de retry e começamos a lidar com eventos antigos

## Mudanças Propostas

Foi adicionado a parte de retry e começamos a lidar com eventos antigos

## Testes Realizados

Testes de unidade e integração

## Cobertura de Testes

O mínimo é 95%, está em 100%

## Problemas Conhecidos

Hoje a parte de Event validation quando é salva no redis e modificada, não é atômica, então possivelmente em alta concorrência teríamos problemas.

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
