### PR TITLE
Feature/integrate clean inventories by product id on delete product and fail create product

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/ProductInventoryGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/ProductInventoryGateway.java
@@ -9,5 +9,7 @@ public interface ProductInventoryGateway {
 
     Either<NotificationHandler, Void> createInventory(String productId, List<CreateInventoryParams> inventoryParams);
 
+    Either<NotificationHandler, Void> cleanInventoriesByProductId(String productId);
+
     record CreateInventoryParams(String sku, int quantity) {}
 }

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/create/DefaultCreateProductUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/create/DefaultCreateProductUseCase.java
@@ -78,6 +78,7 @@ public class DefaultCreateProductUseCase extends CreateProductUseCase {
         final var aResult = this.createProduct(aProduct);
 
         if (aResult.isFailure()) {
+            this.productInventoryGateway.cleanInventoriesByProductId(aProduct.getId().getValue());
             throw TransactionFailureException.with(aResult.getErrorResult());
         }
 

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/search/remove/RemoveProductUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/search/remove/RemoveProductUseCase.java
@@ -3,6 +3,7 @@ package com.kaua.ecommerce.application.usecases.product.search.remove;
 import com.kaua.ecommerce.application.UnitUseCase;
 import com.kaua.ecommerce.application.gateways.MediaResourceGateway;
 import com.kaua.ecommerce.application.gateways.ProductGateway;
+import com.kaua.ecommerce.application.gateways.ProductInventoryGateway;
 import com.kaua.ecommerce.application.gateways.SearchGateway;
 import com.kaua.ecommerce.domain.product.Product;
 
@@ -13,15 +14,18 @@ public class RemoveProductUseCase extends UnitUseCase<String> {
     private final ProductGateway productGateway;
     private final MediaResourceGateway mediaResourceGateway;
     private final SearchGateway<Product> productSearchGateway;
+    private final ProductInventoryGateway productInventoryGateway;
 
     public RemoveProductUseCase(
             final ProductGateway productGateway,
             final MediaResourceGateway mediaResourceGateway,
-            final SearchGateway<Product> productSearchGateway
+            final SearchGateway<Product> productSearchGateway,
+            final ProductInventoryGateway productInventoryGateway
     ) {
         this.productGateway = Objects.requireNonNull(productGateway);
         this.mediaResourceGateway = Objects.requireNonNull(mediaResourceGateway);
         this.productSearchGateway = Objects.requireNonNull(productSearchGateway);
+        this.productInventoryGateway = Objects.requireNonNull(productInventoryGateway);
     }
 
     @Override
@@ -35,6 +39,7 @@ public class RemoveProductUseCase extends UnitUseCase<String> {
                     aProduct.getBannerImage().ifPresent(this.mediaResourceGateway::clearImage);
                     this.productGateway.delete(aId);
                 });
+        this.productInventoryGateway.cleanInventoriesByProductId(aId);
         this.productSearchGateway.deleteById(aId);
     }
 }

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/product/create/CreateProductUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/product/create/CreateProductUseCaseTest.java
@@ -592,6 +592,8 @@ public class CreateProductUseCaseTest extends UseCaseTest {
                 .thenReturn(Either.right(null));
         Mockito.when(this.transactionManager.execute(Mockito.any())).thenReturn(TransactionResult
                 .failure(new Error(expectedErrorMessage)));
+        Mockito.when(this.productInventoryGateway.cleanInventoriesByProductId(Mockito.any()))
+                .thenReturn(Either.right(null));
 
         final var aOutput = Assertions.assertThrows(
                 TransactionFailureException.class,
@@ -605,5 +607,7 @@ public class CreateProductUseCaseTest extends UseCaseTest {
         Mockito.verify(productGateway, Mockito.times(0)).create(Mockito.any());
         Mockito.verify(transactionManager, Mockito.times(1)).execute(Mockito.any());
         Mockito.verify(eventPublisher, Mockito.times(0)).publish(Mockito.any());
+        Mockito.verify(productInventoryGateway, Mockito.times(1))
+                .cleanInventoriesByProductId(Mockito.any());
     }
 }

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/product/search/remove/RemoveProductUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/product/search/remove/RemoveProductUseCaseTest.java
@@ -1,27 +1,20 @@
 package com.kaua.ecommerce.application.usecases.product.search.remove;
 
 import com.kaua.ecommerce.application.UseCaseTest;
+import com.kaua.ecommerce.application.either.Either;
 import com.kaua.ecommerce.application.gateways.MediaResourceGateway;
 import com.kaua.ecommerce.application.gateways.ProductGateway;
+import com.kaua.ecommerce.application.gateways.ProductInventoryGateway;
 import com.kaua.ecommerce.application.gateways.SearchGateway;
-import com.kaua.ecommerce.application.usecases.product.search.save.SaveProductUseCase;
 import com.kaua.ecommerce.domain.Fixture;
-import com.kaua.ecommerce.domain.category.CategoryID;
-import com.kaua.ecommerce.domain.exceptions.DomainException;
-import com.kaua.ecommerce.domain.product.*;
-import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
-import org.junit.jupiter.api.Assertions;
+import com.kaua.ecommerce.domain.product.Product;
+import com.kaua.ecommerce.domain.product.ProductImageType;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import java.math.BigDecimal;
 import java.util.Optional;
-import java.util.Set;
-
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.ArgumentMatchers.eq;
 
 public class RemoveProductUseCaseTest extends UseCaseTest {
 
@@ -33,6 +26,9 @@ public class RemoveProductUseCaseTest extends UseCaseTest {
 
     @Mock
     private SearchGateway<Product> productSearchGateway;
+
+    @Mock
+    private ProductInventoryGateway productInventoryGateway;
 
     @InjectMocks
     private RemoveProductUseCase useCase;
@@ -48,6 +44,8 @@ public class RemoveProductUseCaseTest extends UseCaseTest {
         Mockito.doNothing().when(mediaResourceGateway).clearImage(Mockito.any());
         Mockito.doNothing().when(productGateway).delete(Mockito.any());
         Mockito.doNothing().when(productSearchGateway).deleteById(Mockito.any());
+        Mockito.when(productInventoryGateway.cleanInventoriesByProductId(Mockito.any()))
+                .thenReturn(Either.right(null));
 
         this.useCase.execute(aProduct.getId().getValue());
 
@@ -56,6 +54,7 @@ public class RemoveProductUseCaseTest extends UseCaseTest {
         Mockito.verify(mediaResourceGateway, Mockito.times(1)).clearImage(Mockito.any());
         Mockito.verify(productGateway, Mockito.times(1)).delete(Mockito.any());
         Mockito.verify(productSearchGateway, Mockito.times(1)).deleteById(Mockito.any());
+        Mockito.verify(productInventoryGateway, Mockito.times(1)).cleanInventoriesByProductId(Mockito.any());
     }
 
     @Test
@@ -65,6 +64,8 @@ public class RemoveProductUseCaseTest extends UseCaseTest {
         Mockito.when(productGateway.findById(Mockito.any())).thenReturn(Optional.of(aProduct));
         Mockito.doNothing().when(productGateway).delete(Mockito.any());
         Mockito.doNothing().when(productSearchGateway).deleteById(Mockito.any());
+        Mockito.when(productInventoryGateway.cleanInventoriesByProductId(Mockito.any()))
+                .thenReturn(Either.right(null));
 
         this.useCase.execute(aProduct.getId().getValue());
 
@@ -73,6 +74,7 @@ public class RemoveProductUseCaseTest extends UseCaseTest {
         Mockito.verify(mediaResourceGateway, Mockito.times(0)).clearImage(Mockito.any());
         Mockito.verify(productGateway, Mockito.times(1)).delete(Mockito.any());
         Mockito.verify(productSearchGateway, Mockito.times(1)).deleteById(Mockito.any());
+        Mockito.verify(productInventoryGateway, Mockito.times(1)).cleanInventoriesByProductId(Mockito.any());
     }
 
     @Test
@@ -81,6 +83,8 @@ public class RemoveProductUseCaseTest extends UseCaseTest {
 
         Mockito.when(productGateway.findById(Mockito.any())).thenReturn(Optional.empty());
         Mockito.doNothing().when(productSearchGateway).deleteById(Mockito.any());
+        Mockito.when(productInventoryGateway.cleanInventoriesByProductId(Mockito.any()))
+                .thenReturn(Either.right(null));
 
         this.useCase.execute(aProductId);
 
@@ -89,5 +93,6 @@ public class RemoveProductUseCaseTest extends UseCaseTest {
         Mockito.verify(mediaResourceGateway, Mockito.times(0)).clearImage(Mockito.any());
         Mockito.verify(productGateway, Mockito.times(0)).delete(Mockito.any());
         Mockito.verify(productSearchGateway, Mockito.times(1)).deleteById(Mockito.any());
+        Mockito.verify(productInventoryGateway, Mockito.times(1)).cleanInventoriesByProductId(Mockito.any());
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
@@ -117,7 +117,12 @@ public class ProductUseCaseConfig {
 
     @Bean
     public RemoveProductUseCase removeProductUseCase() {
-        return new RemoveProductUseCase(productGateway, mediaResourceGateway, productSearchGateway);
+        return new RemoveProductUseCase(
+                productGateway,
+                mediaResourceGateway,
+                productSearchGateway,
+                productInventoryGateway
+        );
     }
 
     @Bean


### PR DESCRIPTION
## Descrição

Foi adicionado a exclusão de todos os inventories de um produto caso falhe a criação do produto e foi adicionado também a exclusão de todos os inventories de um produto quando ele é deletado

## Mudanças Propostas

N/A

## Testes Realizados

Testes de unidade e integração

## Cobertura de Testes

O mínimo é 95%, está em 100%

## Problemas Conhecidos

N/A

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
