### PR TITLE
Feature/integrate delete by SKU on remove attribute

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/ProductInventoryGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/ProductInventoryGateway.java
@@ -11,5 +11,7 @@ public interface ProductInventoryGateway {
 
     Either<NotificationHandler, Void> cleanInventoriesByProductId(String productId);
 
+    Either<NotificationHandler, Void> deleteInventoryBySku(String sku);
+
     record CreateInventoryParams(String sku, int quantity) {}
 }

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/attributes/remove/DefaultRemoveProductAttributesUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/attributes/remove/DefaultRemoveProductAttributesUseCase.java
@@ -6,6 +6,8 @@ import com.kaua.ecommerce.application.exceptions.ProductNotHaveMoreAttributesExc
 import com.kaua.ecommerce.application.exceptions.TransactionFailureException;
 import com.kaua.ecommerce.application.gateways.EventPublisher;
 import com.kaua.ecommerce.application.gateways.ProductGateway;
+import com.kaua.ecommerce.application.gateways.ProductInventoryGateway;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
 import com.kaua.ecommerce.domain.exceptions.NotFoundException;
 import com.kaua.ecommerce.domain.product.Product;
 import com.kaua.ecommerce.domain.product.ProductStatus;
@@ -18,15 +20,18 @@ public class DefaultRemoveProductAttributesUseCase extends RemoveProductAttribut
     private final ProductGateway productGateway;
     private final TransactionManager transactionManager;
     private final EventPublisher eventPublisher;
+    private final ProductInventoryGateway productInventoryGateway;
 
     public DefaultRemoveProductAttributesUseCase(
             final ProductGateway productGateway,
             final TransactionManager transactionManager,
-            final EventPublisher eventPublisher
+            final EventPublisher eventPublisher,
+            final ProductInventoryGateway productInventoryGateway
     ) {
         this.productGateway = Objects.requireNonNull(productGateway);
         this.transactionManager = Objects.requireNonNull(transactionManager);
         this.eventPublisher = Objects.requireNonNull(eventPublisher);
+        this.productInventoryGateway = Objects.requireNonNull(productInventoryGateway);
     }
 
     @Override
@@ -45,6 +50,13 @@ public class DefaultRemoveProductAttributesUseCase extends RemoveProductAttribut
         final var aResultAfterCallRemove = aProduct.removeAttribute(input.sku());
 
         if (aResultAfterCallRemove != null) {
+            final var aResultOnDeleteInventory = this.productInventoryGateway
+                    .deleteInventoryBySku(input.sku());
+
+            if (aResultOnDeleteInventory.isLeft()) {
+                throw DomainException.with(aResultOnDeleteInventory.getLeft().getErrors());
+            }
+
             final var aTransactionResult = this.transactionManager.execute(() -> {
                 final var aUpdateResult = this.productGateway.update(aResultAfterCallRemove);
                 this.eventPublisher.publish(ProductUpdatedEvent.from(aResultAfterCallRemove));
@@ -52,6 +64,11 @@ public class DefaultRemoveProductAttributesUseCase extends RemoveProductAttribut
             });
 
             if (aTransactionResult.isFailure()) {
+                // TODO: precisamos de uma forma para compensar o pagamento
+                // alguma forma de dar rollback, ou buscamos o inventory pra deixar in-memory
+                // ou então usamos o inventory movement para restaurar a versão antiga do inventory
+                // o inventory movement dai tem um IN, OUT e DELETED status, para sabermos quando
+                // um inventory foi removido, e podemos restaurar ele
                 throw TransactionFailureException.with(aTransactionResult.getErrorResult());
             }
         }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
@@ -107,7 +107,7 @@ public class ProductUseCaseConfig {
 
     @Bean
     public RemoveProductAttributesUseCase removeProductAttributesUseCase() {
-        return new DefaultRemoveProductAttributesUseCase(productGateway, transactionManager, eventPublisher);
+        return new DefaultRemoveProductAttributesUseCase(productGateway, transactionManager, eventPublisher, productInventoryGateway);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductInventoryUseCaseGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/ProductInventoryUseCaseGateway.java
@@ -6,6 +6,7 @@ import com.kaua.ecommerce.application.usecases.inventory.create.CreateInventoryU
 import com.kaua.ecommerce.application.usecases.inventory.create.commands.CreateInventoryCommand;
 import com.kaua.ecommerce.application.usecases.inventory.create.commands.CreateInventoryCommandParams;
 import com.kaua.ecommerce.application.usecases.inventory.delete.clean.CleanInventoriesByProductIdUseCase;
+import com.kaua.ecommerce.application.usecases.inventory.delete.remove.RemoveInventoryBySkuUseCase;
 import com.kaua.ecommerce.domain.validation.Error;
 import com.kaua.ecommerce.domain.validation.handler.NotificationHandler;
 import org.slf4j.Logger;
@@ -23,13 +24,16 @@ public class ProductInventoryUseCaseGateway implements ProductInventoryGateway {
 
     private final CreateInventoryUseCase createInventoryUseCase;
     private final CleanInventoriesByProductIdUseCase cleanInventoriesByProductIdUseCase;
+    private final RemoveInventoryBySkuUseCase removeInventoryBySkuUseCase;
 
     public ProductInventoryUseCaseGateway(
             final CreateInventoryUseCase createInventoryUseCase,
-            final CleanInventoriesByProductIdUseCase cleanInventoriesByProductIdUseCase
+            final CleanInventoriesByProductIdUseCase cleanInventoriesByProductIdUseCase,
+            final RemoveInventoryBySkuUseCase removeInventoryBySkuUseCase
     ) {
         this.createInventoryUseCase = Objects.requireNonNull(createInventoryUseCase);
         this.cleanInventoriesByProductIdUseCase = Objects.requireNonNull(cleanInventoriesByProductIdUseCase);
+        this.removeInventoryBySkuUseCase = Objects.requireNonNull(removeInventoryBySkuUseCase);
     }
 
     @Override
@@ -60,11 +64,25 @@ public class ProductInventoryUseCaseGateway implements ProductInventoryGateway {
     public Either<NotificationHandler, Void> cleanInventoriesByProductId(String productId) {
         try {
             this.cleanInventoriesByProductIdUseCase.execute(productId);
+            log.info("inventories success cleaned by product id: {}", productId);
             return Either.right(null);
         } catch (Exception e) {
             log.error("error on clean inventories by product id", e);
             return Either.left(NotificationHandler.create()
-                    .append(new Error("error on clean inventories by product id")));
+                    .append(new Error("error on clean inventories by product id %s".formatted(productId))));
+        }
+    }
+
+    @Override
+    public Either<NotificationHandler, Void> deleteInventoryBySku(String sku) {
+        try {
+            this.removeInventoryBySkuUseCase.execute(sku);
+            log.info("inventory success deleted by sku: {}", sku);
+            return Either.right(null);
+        } catch (Exception e) {
+            log.error("error on delete inventory by sku", e);
+            return Either.left(NotificationHandler.create()
+                    .append(new Error("error on delete inventory by sku %s".formatted(sku))));
         }
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/application/product/attributes/remove/RemoveProductAttributesUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/application/product/attributes/remove/RemoveProductAttributesUseCaseIT.java
@@ -1,5 +1,7 @@
 package com.kaua.ecommerce.application.product.attributes.remove;
 
+import com.kaua.ecommerce.application.either.Either;
+import com.kaua.ecommerce.application.gateways.ProductInventoryGateway;
 import com.kaua.ecommerce.application.usecases.product.attributes.remove.RemoveProductAttributesCommand;
 import com.kaua.ecommerce.application.usecases.product.attributes.remove.RemoveProductAttributesUseCase;
 import com.kaua.ecommerce.domain.Fixture;
@@ -8,13 +10,18 @@ import com.kaua.ecommerce.infrastructure.product.persistence.ProductJpaEntity;
 import com.kaua.ecommerce.infrastructure.product.persistence.ProductJpaRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @IntegrationTest
 public class RemoveProductAttributesUseCaseIT {
 
     @Autowired
     private ProductJpaRepository productJpaRepository;
+
+    @MockBean
+    private ProductInventoryGateway productInventoryGateway;
 
     @Autowired
     private RemoveProductAttributesUseCase removeProductAttributesUseCase;
@@ -31,6 +38,9 @@ public class RemoveProductAttributesUseCaseIT {
 
         this.productJpaRepository.save(ProductJpaEntity.toEntity(aProduct));
 
+        Mockito.when(this.productInventoryGateway.deleteInventoryBySku(aSku))
+                .thenReturn(Either.right(null));
+
         Assertions.assertEquals(1, this.productJpaRepository.count());
 
         final var aCommand = RemoveProductAttributesCommand.with(aProductId, aSku);
@@ -42,5 +52,7 @@ public class RemoveProductAttributesUseCaseIT {
         final var aProductEntity = this.productJpaRepository.findById(aProductId).get();
 
         Assertions.assertEquals(1, aProductEntity.getAttributes().size());
+
+        Mockito.verify(this.productInventoryGateway, Mockito.times(1)).deleteInventoryBySku(aSku);
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductInventoryUseCaseGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/product/ProductInventoryUseCaseGatewayTest.java
@@ -3,6 +3,7 @@ package com.kaua.ecommerce.infrastructure.product;
 import com.kaua.ecommerce.application.gateways.ProductInventoryGateway;
 import com.kaua.ecommerce.application.usecases.inventory.create.CreateInventoryUseCase;
 import com.kaua.ecommerce.application.usecases.inventory.delete.clean.CleanInventoriesByProductIdUseCase;
+import com.kaua.ecommerce.application.usecases.inventory.delete.remove.RemoveInventoryBySkuUseCase;
 import com.kaua.ecommerce.domain.Fixture;
 import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
 import com.kaua.ecommerce.infrastructure.IntegrationTest;
@@ -115,7 +116,8 @@ public class ProductInventoryUseCaseGatewayTest {
         final var aMockCleanInventoriesByProductIdUseCase = Mockito.mock(CleanInventoriesByProductIdUseCase.class);
         final var aMockProductInventoryGateway = new ProductInventoryUseCaseGateway(
                 Mockito.mock(CreateInventoryUseCase.class),
-                aMockCleanInventoriesByProductIdUseCase
+                aMockCleanInventoriesByProductIdUseCase,
+                Mockito.mock(RemoveInventoryBySkuUseCase.class)
         );
 
         final var aProductId = "invalid-id";
@@ -125,6 +127,52 @@ public class ProductInventoryUseCaseGatewayTest {
         final var aOutput = aMockProductInventoryGateway.cleanInventoriesByProductId(aProductId);
 
         Assertions.assertTrue(aOutput.isLeft());
-        Assertions.assertEquals("error on clean inventories by product id", aOutput.getLeft().getErrors().get(0).message());
+        Assertions.assertEquals("error on clean inventories by product id %s".formatted(aProductId), aOutput.getLeft().getErrors().get(0).message());
+    }
+
+    @Test
+    void givenAValidSku_whenCallRemoveInventoryBySku_thenShouldRemoveInventory() {
+        final var aProduct = Fixture.Products.book();
+        this.productJpaRepository.saveAndFlush(ProductJpaEntity.toEntity(aProduct));
+
+        final var aProductId = aProduct.getId().getValue();
+        final var aProductSku = aProduct.getAttributes().stream().findFirst().get().getSku();
+        final var aQuantity = 5;
+
+        final var aInventoryParams = new ProductInventoryGateway.CreateInventoryParams(
+                aProductSku,
+                aQuantity
+        );
+
+        this.productInventoryGateway.createInventory(
+                aProductId,
+                List.of(aInventoryParams)
+        );
+
+        Assertions.assertEquals(1, this.inventoryJpaRepository.count());
+
+        final var aOutput = this.productInventoryGateway.deleteInventoryBySku(aProductSku);
+
+        Assertions.assertEquals(0, this.inventoryJpaRepository.count());
+        Assertions.assertTrue(aOutput.isRight());
+    }
+
+    @Test
+    void givenAnInvalidSku_whenCallRemoveInventoryBySku_thenReturnNotificationHandlerWithException() {
+        final var aMockRemoveInventoryBySkuUseCase = Mockito.mock(RemoveInventoryBySkuUseCase.class);
+        final var aMockProductInventoryGateway = new ProductInventoryUseCaseGateway(
+                Mockito.mock(CreateInventoryUseCase.class),
+                Mockito.mock(CleanInventoriesByProductIdUseCase.class),
+                aMockRemoveInventoryBySkuUseCase
+        );
+
+        final var aSku = "invalid-sku";
+
+        Mockito.doThrow(new RuntimeException()).when(aMockRemoveInventoryBySkuUseCase).execute(aSku);
+
+        final var aOutput = aMockProductInventoryGateway.deleteInventoryBySku(aSku);
+
+        Assertions.assertTrue(aOutput.isLeft());
+        Assertions.assertEquals("error on delete inventory by sku %s".formatted(aSku), aOutput.getLeft().getErrors().get(0).message());
     }
 }


### PR DESCRIPTION
## Descrição

Foi adicionado parcialmente a integração para deletar o inventory quando um atributo é removido, falta ter uma opção para voltar atrás caso a remoção do atributo falhe

## Mudanças Propostas

Foi adicionado parcialmente a integração para deletar o inventory quando um atributo é removido, falta ter uma opção para voltar atrás caso a remoção do atributo falhe

## Testes Realizados

Testes de unidade e integração

## Cobertura de Testes

O mínimo é 95%, está em 100%

## Problemas Conhecidos

Hoje se o inventory for deletado, mas o atributo falhar ao ser removido, o inventory não ira existir, o certo é adicionarmos o inventory movement, com um status IN e OUT, talvez um DELETED junto e em caso de falha pegamos o último inventory movement e re-criamos o inventory

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
