### PR TITLE
Feature/integrate create inventory on add attributes

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/product/attributes/add/AddProductAttributesCommandParams.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/product/attributes/add/AddProductAttributesCommandParams.java
@@ -6,6 +6,7 @@ public record AddProductAttributesCommandParams(
         double weight,
         double height,
         double width,
-        double depth
+        double depth,
+        int quantity
 ) {
 }

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/product/attributes/add/AddProductAttributesUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/product/attributes/add/AddProductAttributesUseCaseTest.java
@@ -3,13 +3,16 @@ package com.kaua.ecommerce.application.usecases.product.attributes.add;
 import com.kaua.ecommerce.application.UseCaseTest;
 import com.kaua.ecommerce.application.adapters.TransactionManager;
 import com.kaua.ecommerce.application.adapters.responses.TransactionResult;
+import com.kaua.ecommerce.application.either.Either;
 import com.kaua.ecommerce.application.exceptions.TransactionFailureException;
 import com.kaua.ecommerce.application.gateways.EventPublisher;
 import com.kaua.ecommerce.application.gateways.ProductGateway;
+import com.kaua.ecommerce.application.gateways.ProductInventoryGateway;
 import com.kaua.ecommerce.domain.Fixture;
 import com.kaua.ecommerce.domain.exceptions.DomainException;
 import com.kaua.ecommerce.domain.product.ProductStatus;
 import com.kaua.ecommerce.domain.validation.Error;
+import com.kaua.ecommerce.domain.validation.handler.NotificationHandler;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -35,6 +38,9 @@ public class AddProductAttributesUseCaseTest extends UseCaseTest {
     @Mock
     private EventPublisher eventPublisher;
 
+    @Mock
+    private ProductInventoryGateway productInventoryGateway;
+
     @InjectMocks
     private DefaultAddProductAttributesUseCase addProductAttributesUseCase;
 
@@ -44,6 +50,7 @@ public class AddProductAttributesUseCaseTest extends UseCaseTest {
         final var aProductId = aProduct.getId().getValue();
 
         final var aProductAttribute = Fixture.Products.productAttributes(aProduct.getName());
+        final var aQuantity = 5;
 
         final var aProductUpdatedAt = aProduct.getUpdatedAt();
 
@@ -54,10 +61,13 @@ public class AddProductAttributesUseCaseTest extends UseCaseTest {
                         aProductAttribute.getSize().getWeight(),
                         aProductAttribute.getSize().getHeight(),
                         aProductAttribute.getSize().getWidth(),
-                        aProductAttribute.getSize().getDepth()
+                        aProductAttribute.getSize().getDepth(),
+                        aQuantity
                 )));
 
         Mockito.when(productGateway.findById(aProductId)).thenReturn(Optional.of(aProduct));
+        Mockito.when(productInventoryGateway.createInventory(Mockito.any(), Mockito.anyList()))
+                .thenReturn(Either.right(null));
         Mockito.when(productGateway.update(aProduct)).thenAnswer(returnsFirstArg());
         Mockito.when(this.transactionManager.execute(Mockito.any())).thenAnswer(it -> {
             final var aSupplier = it.getArgument(0, Supplier.class);
@@ -71,6 +81,8 @@ public class AddProductAttributesUseCaseTest extends UseCaseTest {
         Assertions.assertEquals(aProductId, aOutput.productId());
 
         Mockito.verify(productGateway, Mockito.times(1)).findById(aProductId);
+        Mockito.verify(productInventoryGateway, Mockito.times(1))
+                .createInventory(Mockito.any(), Mockito.anyList());
         Mockito.verify(productGateway, Mockito.times(1)).update(argThat(aCmd ->
                 Objects.equals(aProductId, aCmd.getId().getValue())
                         && Objects.equals(2, aCmd.getAttributes().size())
@@ -87,6 +99,7 @@ public class AddProductAttributesUseCaseTest extends UseCaseTest {
         final var aProductAttribute = Fixture.Products.productAttributes(aProduct.getName());
 
         final var aProductId = aProduct.getId().getValue();
+        final var aQuantity = 5;
 
         final var expectedErrorMessage = "Product with id %s is deleted".formatted(aProductId);
 
@@ -97,7 +110,8 @@ public class AddProductAttributesUseCaseTest extends UseCaseTest {
                         aProductAttribute.getSize().getWeight(),
                         aProductAttribute.getSize().getHeight(),
                         aProductAttribute.getSize().getWidth(),
-                        aProductAttribute.getSize().getDepth()
+                        aProductAttribute.getSize().getDepth(),
+                        aQuantity
                 )));
 
         Mockito.when(productGateway.findById(aProductId)).thenReturn(Optional.of(aProduct));
@@ -136,11 +150,12 @@ public class AddProductAttributesUseCaseTest extends UseCaseTest {
     }
 
     @Test
-    void givenAValidCommand_whenCallExecuteButThrowsOnPublishEvent_thenShouldThrowTransactionFailureException() {
+    void givenAValidCommand_whenCallExecuteButOnCreateInventoriesThrows_thenShouldThrowDomainException() {
         final var aProduct = Fixture.Products.tshirt();
         final var aProductAttribute = Fixture.Products.productAttributes(aProduct.getName());
 
         final var aProductId = aProduct.getId().getValue();
+        final var aQuantity = 5;
 
         final var aCommand = AddProductAttributesCommand.with(
                 aProductId, List.of(new AddProductAttributesCommandParams(
@@ -149,14 +164,55 @@ public class AddProductAttributesUseCaseTest extends UseCaseTest {
                         aProductAttribute.getSize().getWeight(),
                         aProductAttribute.getSize().getHeight(),
                         aProductAttribute.getSize().getWidth(),
-                        aProductAttribute.getSize().getDepth()
+                        aProductAttribute.getSize().getDepth(),
+                        aQuantity
+                )));
+
+        final var expectedErrorMessage = "Error on create inventories";
+
+        Mockito.when(productGateway.findById(aProductId)).thenReturn(Optional.of(aProduct));
+        Mockito.when(productInventoryGateway.createInventory(Mockito.any(), Mockito.anyList()))
+                .thenReturn(Either.left(NotificationHandler.create(new Error(expectedErrorMessage))));
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> this.addProductAttributesUseCase.execute(aCommand));
+
+        Assertions.assertNotNull(aException);
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+
+        Mockito.verify(productGateway, Mockito.times(1)).findById(aProductId);
+        Mockito.verify(productInventoryGateway, Mockito.times(1))
+                .createInventory(Mockito.any(), Mockito.anyList());
+        Mockito.verify(productGateway, Mockito.times(0)).update(Mockito.any());
+    }
+
+    @Test
+    void givenAValidCommand_whenCallExecuteButThrowsOnPublishEvent_thenShouldThrowTransactionFailureException() {
+        final var aProduct = Fixture.Products.tshirt();
+        final var aProductAttribute = Fixture.Products.productAttributes(aProduct.getName());
+
+        final var aProductId = aProduct.getId().getValue();
+        final var aQuantity = 5;
+
+        final var aCommand = AddProductAttributesCommand.with(
+                aProductId, List.of(new AddProductAttributesCommandParams(
+                        aProductAttribute.getColor().getColor(),
+                        aProductAttribute.getSize().getSize(),
+                        aProductAttribute.getSize().getWeight(),
+                        aProductAttribute.getSize().getHeight(),
+                        aProductAttribute.getSize().getWidth(),
+                        aProductAttribute.getSize().getDepth(),
+                        aQuantity
                 )));
 
         final var expectedErrorMessage = "Error on publish event";
 
         Mockito.when(productGateway.findById(aProductId)).thenReturn(Optional.of(aProduct));
+        Mockito.when(productInventoryGateway.createInventory(Mockito.any(), Mockito.anyList()))
+                .thenReturn(Either.right(null));
         Mockito.when(this.transactionManager.execute(Mockito.any())).thenReturn(TransactionResult
                 .failure(new Error(expectedErrorMessage)));
+        Mockito.doNothing().when(this.eventPublisher).publish(Mockito.any());
 
         final var aOutput = Assertions.assertThrows(
                 TransactionFailureException.class,
@@ -165,6 +221,9 @@ public class AddProductAttributesUseCaseTest extends UseCaseTest {
         Assertions.assertEquals(expectedErrorMessage, aOutput.getMessage());
 
         Mockito.verify(productGateway, Mockito.times(1)).findById(aProduct.getId().getValue());
+        Mockito.verify(productInventoryGateway, Mockito.times(1))
+                .createInventory(Mockito.any(), Mockito.anyList());
         Mockito.verify(productGateway, Mockito.times(0)).update(Mockito.any());
+        Mockito.verify(eventPublisher, Mockito.times(1)).publish(Mockito.any());
     }
 }

--- a/domain/src/main/java/com/kaua/ecommerce/domain/event/EventsTypes.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/event/EventsTypes.java
@@ -10,5 +10,7 @@ public final class EventsTypes {
     public static final String PRODUCT_UPDATED = "product_updated";
     public static final String PRODUCT_DELETED = "product_deleted";
 
+    public static final String INVENTORY_CREATED_ROLLBACK_BY_SKUS = "inventory_created_rollback_by_skus";
+
     private EventsTypes() {}
 }

--- a/domain/src/main/java/com/kaua/ecommerce/domain/inventory/events/InventoryCreatedRollbackBySkusEvent.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/inventory/events/InventoryCreatedRollbackBySkusEvent.java
@@ -1,0 +1,30 @@
+package com.kaua.ecommerce.domain.inventory.events;
+
+import com.kaua.ecommerce.domain.event.DomainEvent;
+import com.kaua.ecommerce.domain.event.EventsTypes;
+import com.kaua.ecommerce.domain.inventory.Inventory;
+import com.kaua.ecommerce.domain.utils.InstantUtils;
+
+import java.time.Instant;
+import java.util.List;
+
+public record InventoryCreatedRollbackBySkusEvent(
+        List<String> skus,
+        String aggregateName,
+        String eventType,
+        Instant occurredOn
+) implements DomainEvent {
+
+    private InventoryCreatedRollbackBySkusEvent(final List<String> skus) {
+        this(
+                skus,
+                Inventory.class.getSimpleName().toLowerCase(),
+                EventsTypes.INVENTORY_CREATED_ROLLBACK_BY_SKUS,
+                InstantUtils.now()
+        );
+    }
+
+    public static InventoryCreatedRollbackBySkusEvent from(final List<String> skus) {
+        return new InventoryCreatedRollbackBySkusEvent(skus);
+    }
+}

--- a/domain/src/test/java/com/kaua/ecommerce/domain/inventory/InventoryTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/inventory/InventoryTest.java
@@ -2,9 +2,13 @@ package com.kaua.ecommerce.domain.inventory;
 
 import com.kaua.ecommerce.domain.Fixture;
 import com.kaua.ecommerce.domain.UnitTest;
+import com.kaua.ecommerce.domain.event.EventsTypes;
+import com.kaua.ecommerce.domain.inventory.events.InventoryCreatedRollbackBySkusEvent;
 import com.kaua.ecommerce.domain.validation.handler.ThrowsValidationHandler;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 public class InventoryTest extends UnitTest {
 
@@ -86,5 +90,17 @@ public class InventoryTest extends UnitTest {
         Assertions.assertTrue(aInventoryString.contains(String.valueOf(aInventory.getQuantity())));
         Assertions.assertTrue(aInventoryString.contains(aInventory.getCreatedAt().toString()));
         Assertions.assertTrue(aInventoryString.contains(aInventory.getUpdatedAt().toString()));
+    }
+
+    @Test
+    void givenAValidSkus_whenCallInventoryCreatedRollbackBySkusEventFrom_shouldReturnEvent() {
+        final var skus = Fixture.createSku("tshirt");
+
+        final var aEvent = InventoryCreatedRollbackBySkusEvent.from(List.of(skus));
+
+        Assertions.assertEquals(1, aEvent.skus().size());
+        Assertions.assertEquals(Inventory.class.getSimpleName().toLowerCase(), aEvent.aggregateName());
+        Assertions.assertEquals(EventsTypes.INVENTORY_CREATED_ROLLBACK_BY_SKUS, aEvent.eventType());
+        Assertions.assertNotNull(aEvent.occurredOn());
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/ProductUseCaseConfig.java
@@ -102,7 +102,7 @@ public class ProductUseCaseConfig {
 
     @Bean
     public AddProductAttributesUseCase addProductAttributesUseCase() {
-        return new DefaultAddProductAttributesUseCase(productGateway, transactionManager, eventPublisher);
+        return new DefaultAddProductAttributesUseCase(productGateway, transactionManager, eventPublisher, productInventoryGateway);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/listeners/InventoryEventListener.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/listeners/InventoryEventListener.java
@@ -1,0 +1,120 @@
+package com.kaua.ecommerce.infrastructure.listeners;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.kaua.ecommerce.application.usecases.inventory.delete.remove.RemoveInventoryBySkuUseCase;
+import com.kaua.ecommerce.domain.event.EventsTypes;
+import com.kaua.ecommerce.domain.inventory.events.InventoryCreatedRollbackBySkusEvent;
+import com.kaua.ecommerce.domain.utils.InstantUtils;
+import com.kaua.ecommerce.infrastructure.configurations.json.Json;
+import com.kaua.ecommerce.infrastructure.listeners.models.MessageValue;
+import com.kaua.ecommerce.infrastructure.outbox.OutboxEventEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+import org.springframework.kafka.annotation.DltHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.adapter.ConsumerRecordMetadata;
+import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Objects;
+
+@Component
+public class InventoryEventListener {
+
+    public static final TypeReference<MessageValue<OutboxEventEntity>> INVENTORY_MESSAGE = new TypeReference<>() {
+    };
+    private static final Logger LOG = LoggerFactory.getLogger(InventoryEventListener.class);
+
+    private static final String EVENT_RECEIVED_MESSAGE = "Inventory {} received from Kafka: {}";
+    private static final String INVENTORY_TOPIC = "inventory-topic";
+    private static final String INVENTORY_DLT_INVALID = "inventory-dlt-invalid";
+
+    private final RemoveInventoryBySkuUseCase removeInventoryBySkuUseCase;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public InventoryEventListener(
+            final RemoveInventoryBySkuUseCase removeInventoryBySkuUseCase,
+            final KafkaTemplate<String, Object> kafkaTemplate
+    ) {
+        this.removeInventoryBySkuUseCase = removeInventoryBySkuUseCase;
+        this.kafkaTemplate = Objects.requireNonNull(kafkaTemplate);
+    }
+
+    @KafkaListener(
+            concurrency = "${kafka.consumers.products.concurrency}",
+            containerFactory = "kafkaListenerFactory",
+            topics = "${kafka.consumers.inventories.topics}",
+            groupId = "${kafka.consumers.inventories.group-id}",
+            id = "${kafka.consumers.inventories.id}",
+            properties = {
+                    "auto.offset.reset=${kafka.consumers.inventories.auto-offset-reset}"
+            }
+    )
+    @RetryableTopic(
+            backoff = @Backoff(delay = 2000, multiplier = 2),
+            attempts = "${kafka.consumers.inventories.max-attempts}",
+            autoCreateTopics = "${kafka.consumers.inventories.auto-create-topics}",
+            dltTopicSuffix = "-retry-dlt",
+            topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
+    )
+    public void onMessage(
+            @Payload final String payload,
+            final Acknowledgment ack,
+            final ConsumerRecordMetadata metadata
+    ) {
+        LOG.atLevel(Level.INFO).log("Message received from Kafka [topic:{}] [partition:{}] [offset:{}]: {}",
+                metadata.topic(), metadata.partition(), metadata.offset(), payload);
+
+        final var aOutBoxEvent = Json.readValue(payload, INVENTORY_MESSAGE).payload().after();
+        final var aInstantNow = InstantUtils.now();
+        final var aDuration = Duration.between(aOutBoxEvent.getOccurredOn(), aInstantNow);
+
+        if (aDuration.toDays() > 10) {
+            this.kafkaTemplate.send(INVENTORY_DLT_INVALID, payload);
+            ack.acknowledge();
+            LOG.error("Event sent to DLT topic: {}, occurred on: {} and now: {}, payload: {}",
+                    INVENTORY_DLT_INVALID, aOutBoxEvent.getOccurredOn(), aInstantNow, payload);
+            return;
+        }
+
+        switch (aOutBoxEvent.getEventType()) {
+            case EventsTypes.INVENTORY_CREATED_ROLLBACK_BY_SKUS -> {
+                final var aInventoryCreatedRollbackBySkus = Json.readValue(
+                        aOutBoxEvent.getData(), InventoryCreatedRollbackBySkusEvent.class);
+
+                final var aSkus = aInventoryCreatedRollbackBySkus.skus();
+                aSkus.forEach(this.removeInventoryBySkuUseCase::execute);
+
+                LOG.info(EVENT_RECEIVED_MESSAGE, "created rollback by skus", aInventoryCreatedRollbackBySkus);
+
+                ack.acknowledge();
+            }
+            default -> LOG.warn("Event type not supported: {}", aOutBoxEvent.getEventType());
+        }
+    }
+
+    @DltHandler
+    public void onDltMessage(
+            @Payload String payload,
+            final Acknowledgment acknowledgment,
+            final ConsumerRecordMetadata metadata
+    ) {
+        LOG.atLevel(Level.WARN).log("Message received from Kafka at DLT [topic:{}] [partition:{}] [offset:{}]: {}",
+                metadata.topic(), metadata.partition(), metadata.offset(), payload);
+
+        final var aOutBoxEvent = Json.readValue(payload, INVENTORY_MESSAGE).payload().after();
+        final var aInstantNow = InstantUtils.now();
+
+        this.kafkaTemplate.send(INVENTORY_TOPIC, payload);
+        acknowledgment.acknowledge();
+        LOG.warn("Event sent to inventory topic for retry: {}, occurred on: {} and now: {}, payload: {}",
+                INVENTORY_TOPIC, aOutBoxEvent.getOccurredOn(), aInstantNow, payload);
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/models/AddProductAttributesInput.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/models/AddProductAttributesInput.java
@@ -17,7 +17,8 @@ public record AddProductAttributesInput(
                         it.weight(),
                         it.height(),
                         it.width(),
-                        it.depth()))
+                        it.depth(),
+                        it.quantity()))
                 .toList();
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/models/AddProductAttributesParamInput.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/product/models/AddProductAttributesParamInput.java
@@ -8,6 +8,7 @@ public record AddProductAttributesParamInput(
         @JsonProperty("weight") double weight,
         @JsonProperty("height") double height,
         @JsonProperty("width") double width,
-        @JsonProperty("depth") double depth
+        @JsonProperty("depth") double depth,
+        @JsonProperty("quantity") int quantity
 ) {
 }

--- a/infrastructure/src/main/resources/application-test-integration-kafka.yml
+++ b/infrastructure/src/main/resources/application-test-integration-kafka.yml
@@ -11,6 +11,8 @@ kafka:
   consumers:
     products:
       auto-create-topics: true
+    inventories:
+      auto-create-topics: true
 
 spring:
   autoconfigure:

--- a/infrastructure/src/main/resources/application-test-integration.yml
+++ b/infrastructure/src/main/resources/application-test-integration.yml
@@ -11,6 +11,8 @@ kafka:
   consumers:
     products:
       auto-create-topics: false
+    inventories:
+      auto-create-topics: false
 
 spring:
   autoconfigure:

--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -48,6 +48,14 @@ kafka:
       group-id: products-group
       max-attempts: 4
       auto-create-topics: false
+    inventories:
+      auto-offset-reset: earliest
+      concurrency: 1
+      id: kafka-listener-inventories
+      topics: inventory-topic
+      group-id: inventories-group
+      max-attempts: 4
+      auto-create-topics: false
 
 server:
   port: 8080

--- a/infrastructure/src/test/java/com/kaua/ecommerce/application/product/attributes/add/AddProductAttributesUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/application/product/attributes/add/AddProductAttributesUseCaseIT.java
@@ -40,7 +40,8 @@ public class AddProductAttributesUseCaseIT {
                         1.0,
                         1.0,
                         1.0,
-                        1.0
+                        1.0,
+                        3
                 ))
         );
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/AbstractEmbeddedKafkaTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/AbstractEmbeddedKafkaTest.java
@@ -1,10 +1,14 @@
 package com.kaua.ecommerce.infrastructure;
 
 import com.kaua.ecommerce.config.IntegrationTestConfiguration;
+import com.kaua.ecommerce.infrastructure.configurations.properties.kafka.KafkaProperties;
 import com.kaua.ecommerce.infrastructure.listeners.models.Source;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -15,13 +19,18 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @EmbeddedKafka(partitions = 1, brokerProperties = {"listeners=PLAINTEXT://localhost:9092", "port=9092"})
 @ActiveProfiles("test-integration-kafka")
@@ -37,8 +46,12 @@ public abstract class AbstractEmbeddedKafkaTest {
     @Autowired
     protected EmbeddedKafkaBroker kafkaBroker;
 
+    @Autowired
+    private KafkaProperties kafkaProperties;
+
     private Producer<String, String> producer;
     private AdminClient admin;
+    private KafkaConsumer<String, String> consumer;
 
     @BeforeAll
     void init() {
@@ -51,6 +64,10 @@ public abstract class AbstractEmbeddedKafkaTest {
     @AfterAll
     void shutdown() {
         producer.close();
+
+        if (consumer != null) {
+            consumer.close();
+        }
 //        admin.close();
 //        kafkaBroker.destroy();
     }
@@ -65,5 +82,33 @@ public abstract class AbstractEmbeddedKafkaTest {
 
     protected Source aSource() {
         return new Source("ecommerce-mysql", "ecommerce", "outbox");
+    }
+
+    protected Map<String, Object> consumerConfigs(final String groupId) {
+        final var props = new HashMap<String, Object>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, kafkaProperties.isAutoCreateTopics());
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, kafkaProperties.isAutoCommit());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        return props;
+    }
+
+    protected void cleanUpMessages(final String groupId, final List<String> topics) {
+        consumer = new KafkaConsumer<>(consumerConfigs(groupId));
+
+        consumer.subscribe(topics);
+
+        while (true) {
+            final var records = consumer.poll(Duration.ofMillis(100));
+            if (records.isEmpty()) {
+                consumer.close();
+                break;
+            }
+
+            consumer.commitSync();
+        }
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/api/ProductAPITest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/api/ProductAPITest.java
@@ -1607,6 +1607,7 @@ public class ProductAPITest {
         final var aProductAttribute = Fixture.Products.productAttributes(aProduct.getName());
 
         final var aId = aProduct.getId().getValue();
+        final var aQuantity = 10;
 
         final var aInput = new AddProductAttributesInput(
                 List.of(new AddProductAttributesParamInput(
@@ -1615,7 +1616,8 @@ public class ProductAPITest {
                         aProductAttribute.getSize().getWeight(),
                         aProductAttribute.getSize().getHeight(),
                         aProductAttribute.getSize().getWidth(),
-                        aProductAttribute.getSize().getDepth()
+                        aProductAttribute.getSize().getDepth(),
+                        aQuantity
                 ))
         );
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/InventoryEventListenerTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/listeners/InventoryEventListenerTest.java
@@ -1,0 +1,230 @@
+package com.kaua.ecommerce.infrastructure.listeners;
+
+import com.kaua.ecommerce.application.usecases.inventory.delete.remove.RemoveInventoryBySkuUseCase;
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.domain.inventory.InventoryID;
+import com.kaua.ecommerce.domain.inventory.events.InventoryCreatedRollbackBySkusEvent;
+import com.kaua.ecommerce.infrastructure.AbstractEmbeddedKafkaTest;
+import com.kaua.ecommerce.infrastructure.configurations.json.Json;
+import com.kaua.ecommerce.infrastructure.listeners.models.MessageValue;
+import com.kaua.ecommerce.infrastructure.listeners.models.Operation;
+import com.kaua.ecommerce.infrastructure.listeners.models.TestListenerDomainEvent;
+import com.kaua.ecommerce.infrastructure.listeners.models.ValuePayload;
+import com.kaua.ecommerce.infrastructure.outbox.OutboxEventEntity;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.adapter.ConsumerRecordMetadata;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.eq;
+
+public class InventoryEventListenerTest extends AbstractEmbeddedKafkaTest {
+
+    @MockBean
+    private RemoveInventoryBySkuUseCase removeInventoryBySkuUseCase;
+
+    @SpyBean
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @SpyBean
+    private InventoryEventListener inventoryEventListener;
+
+    @Value("${kafka.consumers.inventories.topics}")
+    private String inventoryTopic;
+
+    @Captor
+    private ArgumentCaptor<ConsumerRecordMetadata> metadata;
+
+    @AfterEach
+    void clean() {
+        final var aTopicsList = List.of(
+                "inventory-topic",
+                "inventory-topic-retry-0",
+                "inventory-topic-retry-1",
+                "inventory-topic-retry-2",
+                "inventory-topic-retry-dlt",
+                "inventory-dlt-invalid"
+        );
+
+        cleanUpMessages("test-inventory-event-listener", aTopicsList);
+    }
+
+    @Test
+    void givenAValidInventoryCreatedRollbackBySkusEvent_whenReceiveThrowsExceptionAndSendToDLT_shouldResendToPrimaryTopic() throws InterruptedException, ExecutionException {
+        final var expectedMaxAttempts = 4;
+        final var expectedMaxDltAttempts = 1;
+        final var expectedMainTopic = "inventory-topic";
+        final var expectedRetry0Topic = "inventory-topic-retry-0";
+        final var expectedRetry1Topic = "inventory-topic-retry-1";
+        final var expectedRetry2Topic = "inventory-topic-retry-2";
+        final var expectedDltTopic = "inventory-topic-retry-dlt";
+
+        final var aInventory = Fixture.Inventories.tshirtInventory();
+        final var aInventoryCreatedRollbackEvent = InventoryCreatedRollbackBySkusEvent
+                .from(List.of(aInventory.getSku()));
+        final var aOutboxEvent = OutboxEventEntity.from(aInventoryCreatedRollbackEvent);
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.CREATE)));
+
+        final var latch = new CountDownLatch(5);
+
+        Mockito.doAnswer(t -> {
+            latch.countDown();
+            throw new RuntimeException("Error on remove inventory by sku use case");
+        }).when(removeInventoryBySkuUseCase).execute(Mockito.any());
+
+        Mockito.doAnswer(t -> {
+            latch.countDown();
+            return null;
+        }).when(inventoryEventListener).onDltMessage(Mockito.any(), Mockito.any(), Mockito.any());
+
+        producer().send(new ProducerRecord<>(inventoryTopic, aMessage));
+        producer().flush();
+
+        Assertions.assertTrue(latch.await(3, TimeUnit.MINUTES));
+
+        Mockito.verify(inventoryEventListener, Mockito.times(expectedMaxAttempts)).onMessage(eq(aMessage), Mockito.any(), metadata.capture());
+
+        final var allMetas = metadata.getAllValues();
+        Assertions.assertEquals(expectedMainTopic, allMetas.get(0).topic());
+        Assertions.assertEquals(expectedRetry0Topic, allMetas.get(1).topic());
+        Assertions.assertEquals(expectedRetry1Topic, allMetas.get(2).topic());
+        Assertions.assertEquals(expectedRetry2Topic, allMetas.get(3).topic());
+
+        Mockito.verify(inventoryEventListener, Mockito.times(expectedMaxDltAttempts)).onDltMessage(eq(aMessage), Mockito.any(), metadata.capture());
+
+        Assertions.assertEquals(expectedDltTopic, metadata.getValue().topic());
+    }
+
+    @Test
+    void givenAValidInventoryCreatedRollbackBySkusEventButOccurredOnIsAfter10Days_whenReceive_shouldNotProcessIt() throws Exception {
+        // given
+        final var aMockMetadata = Mockito.mock(ConsumerRecordMetadata.class);
+        final var aMockAcknowledgment = Mockito.mock(Acknowledgment.class);
+
+        final var aInventory = Fixture.Inventories.tshirtInventory();
+        final var aInventoryCreatedRollbackEvent = InventoryCreatedRollbackBySkusEvent
+                .from(List.of(aInventory.getSku()));
+        final var aOutboxEvent = OutboxEventEntity.from(aInventoryCreatedRollbackEvent);
+        aOutboxEvent.setOccurredOn(aOutboxEvent.getOccurredOn()
+                .minus(11, ChronoUnit.DAYS));
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.CREATE)));
+
+        final var aLatch = new CountDownLatch(1);
+
+        // when
+        Mockito.when(aMockMetadata.topic()).thenReturn(inventoryTopic);
+        Mockito.when(aMockMetadata.partition()).thenReturn(1);
+        Mockito.when(aMockMetadata.offset()).thenReturn(1L);
+        Mockito.when(aMockMetadata.timestampType()).thenReturn(TimestampType.CREATE_TIME);
+        Mockito.when(aMockMetadata.timestamp()).thenReturn(1L);
+        Mockito.doAnswer(it -> {
+            aLatch.countDown();
+            return null;
+        }).when(aMockAcknowledgment).acknowledge();
+
+        final var aInventoryListener = new InventoryEventListener(removeInventoryBySkuUseCase, kafkaTemplate);
+        aInventoryListener.onMessage(aMessage, aMockAcknowledgment, aMockMetadata);
+
+        // then
+        Assertions.assertTrue(aLatch.await(3, TimeUnit.MINUTES));
+        Mockito.verify(removeInventoryBySkuUseCase, Mockito.times(0))
+                .execute(Mockito.any());
+    }
+
+    @Test
+    void givenAValidInventoryCreatedRollbackBySkusEvent_whenReceive_shouldRemoveInventories() throws Exception {
+        // given
+        final var aInventory = Fixture.Inventories.tshirtInventory();
+        final var aInventoryCreatedRollbackEvent = InventoryCreatedRollbackBySkusEvent
+                .from(List.of(aInventory.getSku()));
+        final var aOutboxEvent = OutboxEventEntity.from(aInventoryCreatedRollbackEvent);
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.CREATE)));
+
+        final var latch = new CountDownLatch(1);
+
+        Mockito.doAnswer(t -> {
+            latch.countDown();
+            return null;
+        }).when(removeInventoryBySkuUseCase).execute(Mockito.any());
+
+        // when
+        producer().send(new ProducerRecord<>(inventoryTopic, aMessage));
+        producer().flush();
+
+        Assertions.assertTrue(latch.await(3, TimeUnit.MINUTES));
+
+        // then
+        Mockito.verify(removeInventoryBySkuUseCase, Mockito.times(1))
+                .execute(Mockito.any());
+    }
+
+    @Test
+    void givenAValidEventButEventTypeDoesNotMatch_whenReceive_shouldDoNothing() {
+        // given
+        final var aOutboxEntity = OutboxEventEntity.from(new
+                TestListenerDomainEvent(InventoryID.unique().getValue()));
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEntity, aOutboxEntity, aSource(), Operation.CREATE)));
+
+        // when
+        producer().send(new ProducerRecord<>(inventoryTopic, aMessage));
+        producer().flush();
+
+        // then
+        Mockito.verify(removeInventoryBySkuUseCase, Mockito.times(0))
+                .execute(Mockito.any());
+    }
+
+    @Test
+    void givenAValidInventoryCreatedRollbackBySkusEvent_whenReceiveOnDLTAndSendToPrimaryTopic_shouldResendToPrimaryTopic() throws Exception {
+        // given
+        final var mockMetadata = Mockito.mock(ConsumerRecordMetadata.class);
+        final var mockAcknowledgment = Mockito.mock(Acknowledgment.class);
+
+        final var aInventory = Fixture.Inventories.tshirtInventory();
+        final var aInventoryCreatedRollbackEvent = InventoryCreatedRollbackBySkusEvent
+                .from(List.of(aInventory.getSku()));
+        final var aOutboxEvent = OutboxEventEntity.from(aInventoryCreatedRollbackEvent);
+
+        final var aMessage = Json.writeValueAsString(new MessageValue<>(new ValuePayload<>(aOutboxEvent, aOutboxEvent, aSource(), Operation.CREATE)));
+
+        final var aLatch = new CountDownLatch(1);
+
+        // when
+        Mockito.when(mockMetadata.topic()).thenReturn(inventoryTopic);
+        Mockito.when(mockMetadata.partition()).thenReturn(1);
+        Mockito.when(mockMetadata.offset()).thenReturn(1L);
+        Mockito.when(mockMetadata.timestampType()).thenReturn(TimestampType.CREATE_TIME);
+        Mockito.when(mockMetadata.timestamp()).thenReturn(1L);
+        Mockito.doAnswer(it -> {
+            aLatch.countDown();
+            return null;
+        }).when(mockAcknowledgment).acknowledge();
+
+        final var aInventoryEventListener = new InventoryEventListener(removeInventoryBySkuUseCase, kafkaTemplate);
+        aInventoryEventListener.onDltMessage(aMessage, mockAcknowledgment, mockMetadata);
+
+        // then
+        Assertions.assertTrue(aLatch.await(3, TimeUnit.MINUTES));
+        Mockito.verify(removeInventoryBySkuUseCase, Mockito.times(0))
+                .execute(Mockito.any());
+    }
+}


### PR DESCRIPTION
## Descrição

Foi adicionado a integração para criar e dar rollback pelo sku caso falhe a transação para atualizar o produto

## Mudanças Propostas

Foi adicionado a integração para criar e dar rollback pelo sku caso falhe a transação para atualizar o produto

## Testes Realizados

Testes de unidade e integração

## Cobertura de Testes

O mínimo é 95%, está em 100%

## Problemas Conhecidos

Ainda precisamos lidar com o caso de rollback caso falhe ao remover o atributo de um produto, o certo vai ser pegar e receber o sku do item removido, fazer uma busca pelo sku + created_at desc pegando o mais atual e recriando o inventory, com isso devemos apagar o removed também

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
