### PR TITLE
Feature/add create order usecase

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/FreightGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/FreightGateway.java
@@ -1,14 +1,14 @@
 package com.kaua.ecommerce.application.gateways;
 
-import com.kaua.ecommerce.application.gateways.commands.CalculateFreightCommand;
-import com.kaua.ecommerce.application.gateways.commands.ListFreightsCommand;
+import com.kaua.ecommerce.application.gateways.commands.CalculateFreightInput;
+import com.kaua.ecommerce.application.gateways.commands.ListFreightsInput;
 import com.kaua.ecommerce.domain.freight.Freight;
 
 import java.util.List;
 
 public interface FreightGateway {
 
-    Freight calculateFreight(CalculateFreightCommand command);
+    Freight calculateFreight(CalculateFreightInput command);
 
-    List<Freight> listFreights(ListFreightsCommand command);
+    List<Freight> listFreights(ListFreightsInput command);
 }

--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/commands/CalculateFreightInput.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/commands/CalculateFreightInput.java
@@ -1,20 +1,24 @@
 package com.kaua.ecommerce.application.gateways.commands;
 
-public record ListFreightsCommand(
+import com.kaua.ecommerce.domain.freight.FreightType;
+
+public record CalculateFreightInput(
         String cep,
+        FreightType type,
         double height,
         double width,
         double length,
         double weight
 ) {
 
-    public static ListFreightsCommand with(
+    public static CalculateFreightInput with(
             final String cep,
+            final FreightType type,
             final double height,
             final double width,
             final double length,
             final double weight
     ) {
-        return new ListFreightsCommand(cep, height, width, length, weight);
+        return new CalculateFreightInput(cep, type, height, width, length, weight);
     }
 }

--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/commands/ListFreightsInput.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/commands/ListFreightsInput.java
@@ -1,24 +1,20 @@
 package com.kaua.ecommerce.application.gateways.commands;
 
-import com.kaua.ecommerce.domain.freight.FreightType;
-
-public record CalculateFreightCommand(
+public record ListFreightsInput(
         String cep,
-        FreightType type,
         double height,
         double width,
         double length,
         double weight
 ) {
 
-    public static CalculateFreightCommand with(
+    public static ListFreightsInput with(
             final String cep,
-            final FreightType type,
             final double height,
             final double width,
             final double length,
             final double weight
     ) {
-        return new CalculateFreightCommand(cep, type, height, width, length, weight);
+        return new ListFreightsInput(cep, height, width, length, weight);
     }
 }

--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderCouponGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderCouponGateway.java
@@ -1,0 +1,13 @@
+package com.kaua.ecommerce.application.gateways.order;
+
+public interface OrderCouponGateway {
+
+    OrderCouponApplyOutput applyCoupon(String couponCode);
+
+    record OrderCouponApplyOutput(
+            String couponId,
+            String couponCode,
+            float couponPercentage
+    ) {
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderCustomerGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderCustomerGateway.java
@@ -1,0 +1,19 @@
+package com.kaua.ecommerce.application.gateways.order;
+
+import java.util.Optional;
+
+public interface OrderCustomerGateway {
+
+    Optional<OrderCustomerOutput> findByCustomerId(String customerId);
+
+    record OrderCustomerOutput(
+            String customerId,
+            String zipCode,
+            String street,
+            String number,
+            String complement,
+            String district,
+            String city,
+            String state
+    ) {}
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderDeliveryGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderDeliveryGateway.java
@@ -1,0 +1,8 @@
+package com.kaua.ecommerce.application.gateways.order;
+
+import com.kaua.ecommerce.domain.order.OrderDelivery;
+
+public interface OrderDeliveryGateway {
+
+    OrderDelivery create(OrderDelivery orderDelivery);
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderFreightGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderFreightGateway.java
@@ -1,0 +1,27 @@
+package com.kaua.ecommerce.application.gateways.order;
+
+import java.util.Set;
+
+public interface OrderFreightGateway {
+
+    OrderFreightDetails calculateFreight(CalculateOrderFreightInput input);
+
+    record CalculateOrderFreightInput(
+            String zipCode,
+            String type,
+            Set<CalculateOrderFreightItemsInput> items
+    ) { }
+
+    record OrderFreightDetails(
+            String type,
+            float price,
+            int deadlineInDays
+    ) { }
+
+    record CalculateOrderFreightItemsInput(
+            double weight,
+            double width,
+            double height,
+            double length
+    ) { }
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderGateway.java
@@ -1,0 +1,15 @@
+package com.kaua.ecommerce.application.gateways.order;
+
+import com.kaua.ecommerce.domain.order.Order;
+import com.kaua.ecommerce.domain.order.OrderItem;
+
+import java.util.Set;
+
+public interface OrderGateway {
+
+    Order create(Order order);
+
+    long count();
+
+    Set<OrderItem> createInBatch(Set<OrderItem> orderItems);
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderPaymentGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderPaymentGateway.java
@@ -1,0 +1,8 @@
+package com.kaua.ecommerce.application.gateways.order;
+
+import com.kaua.ecommerce.domain.order.OrderPayment;
+
+public interface OrderPaymentGateway {
+
+    OrderPayment create(OrderPayment orderPayment);
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderProductGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderProductGateway.java
@@ -1,0 +1,18 @@
+package com.kaua.ecommerce.application.gateways.order;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+public interface OrderProductGateway {
+
+    Optional<OrderProductDetails> getProductDetailsBySku(String sku);
+
+    record OrderProductDetails(
+            String sku,
+            BigDecimal price,
+            double weight,
+            double width,
+            double height,
+            double length
+    ) { }
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/coupon/slot/remove/RemoveCouponSlotOutput.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/coupon/slot/remove/RemoveCouponSlotOutput.java
@@ -4,13 +4,15 @@ import com.kaua.ecommerce.domain.coupon.Coupon;
 
 public record RemoveCouponSlotOutput(
         String couponId,
-        String couponCode
+        String couponCode,
+        float couponPercentage
 ) {
 
     public static RemoveCouponSlotOutput from(final Coupon aCoupon) {
         return new RemoveCouponSlotOutput(
                 aCoupon.getId().getValue(),
-                aCoupon.getCode().getValue()
+                aCoupon.getCode().getValue(),
+                aCoupon.getPercentage()
         );
     }
 }

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/freight/calculate/CalculateFreightCommand.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/freight/calculate/CalculateFreightCommand.java
@@ -1,0 +1,18 @@
+package com.kaua.ecommerce.application.usecases.freight.calculate;
+
+import java.util.Set;
+
+public record CalculateFreightCommand(
+        String zipCode,
+        String type,
+        Set<CalculateFreightItemsCommand> items
+) {
+
+    public static CalculateFreightCommand with(
+            final String zipCode,
+            final String type,
+            final Set<CalculateFreightItemsCommand> items
+    ) {
+        return new CalculateFreightCommand(zipCode, type, items);
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/freight/calculate/CalculateFreightItemsCommand.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/freight/calculate/CalculateFreightItemsCommand.java
@@ -1,0 +1,18 @@
+package com.kaua.ecommerce.application.usecases.freight.calculate;
+
+public record CalculateFreightItemsCommand(
+        double weight,
+        double width,
+        double height,
+        double length
+) {
+
+    public  static CalculateFreightItemsCommand with(
+            final double weight,
+            final double width,
+            final double height,
+            final double length
+    ) {
+        return new CalculateFreightItemsCommand(weight, width, height, length);
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/freight/calculate/CalculateFreightUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/freight/calculate/CalculateFreightUseCase.java
@@ -1,0 +1,7 @@
+package com.kaua.ecommerce.application.usecases.freight.calculate;
+
+import com.kaua.ecommerce.application.UseCase;
+import com.kaua.ecommerce.domain.freight.Freight;
+
+public abstract class CalculateFreightUseCase extends UseCase<Freight, CalculateFreightCommand> {
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/freight/calculate/DefaultCalculateFreightUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/freight/calculate/DefaultCalculateFreightUseCase.java
@@ -1,0 +1,49 @@
+package com.kaua.ecommerce.application.usecases.freight.calculate;
+
+import com.kaua.ecommerce.application.gateways.FreightGateway;
+import com.kaua.ecommerce.application.gateways.commands.CalculateFreightInput;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.freight.Freight;
+import com.kaua.ecommerce.domain.freight.FreightType;
+import com.kaua.ecommerce.domain.validation.Error;
+
+import java.util.Objects;
+
+public class DefaultCalculateFreightUseCase extends CalculateFreightUseCase {
+
+    private final FreightGateway freightGateway;
+
+    public DefaultCalculateFreightUseCase(final FreightGateway freightGateway) {
+        this.freightGateway = Objects.requireNonNull(freightGateway);
+    }
+
+    @Override
+    public Freight execute(CalculateFreightCommand input) {
+        final var aFreightType = FreightType.of(input.type())
+                .orElseThrow(() -> DomainException
+                        .with(new Error("type %s was not found".formatted(input.type()))));
+
+        CalculateFreightItemsCommand aItem = null;
+        double aMaxVolume = 0;
+        for (CalculateFreightItemsCommand item : input.items()) {
+            final var aVolume = item.width() * item.height() * item.length();
+            if (aVolume > aMaxVolume) {
+                aMaxVolume = aVolume;
+                aItem = item;
+            }
+        }
+
+        if (aItem == null) {
+            throw DomainException.with(new Error("No item found to calculate freight"));
+        }
+
+        return this.freightGateway.calculateFreight(CalculateFreightInput.with(
+                input.zipCode(),
+                aFreightType,
+                aItem.height(),
+                aItem.width(),
+                aItem.length(),
+                aItem.weight()
+        ));
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/freight/list/DefaultListFreightsByCepUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/freight/list/DefaultListFreightsByCepUseCase.java
@@ -1,7 +1,7 @@
 package com.kaua.ecommerce.application.usecases.freight.list;
 
 import com.kaua.ecommerce.application.gateways.FreightGateway;
-import com.kaua.ecommerce.application.gateways.commands.ListFreightsCommand;
+import com.kaua.ecommerce.application.gateways.commands.ListFreightsInput;
 import com.kaua.ecommerce.domain.freight.Freight;
 
 import java.util.List;
@@ -17,7 +17,7 @@ public class DefaultListFreightsByCepUseCase extends ListFreightsByCepUseCase {
 
     @Override
     public List<Freight> execute(ListFreightsByCepCommand input) {
-        final var aListFreightsCommand = ListFreightsCommand.with(
+        final var aListFreightsCommand = ListFreightsInput.with(
                 input.cep(),
                 input.height(),
                 input.width(),

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderCommand.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderCommand.java
@@ -1,0 +1,36 @@
+package com.kaua.ecommerce.application.usecases.order.create;
+
+import java.util.Optional;
+import java.util.Set;
+
+public record CreateOrderCommand(
+        String customerId,
+        String couponCode,
+        String freightType,
+        String paymentMethodId,
+        int installments,
+        Set<CreateOrderItemsCommand> items
+) {
+
+    public static CreateOrderCommand with(
+            final String customerId,
+            final String couponCode,
+            final String freightType,
+            final String paymentMethodId,
+            final int installments,
+            final Set<CreateOrderItemsCommand> items
+    ) {
+        return new CreateOrderCommand(
+                customerId,
+                couponCode,
+                freightType,
+                paymentMethodId,
+                installments,
+                items
+        );
+    }
+
+    public Optional<String> getCouponCode() {
+        return couponCode == null || couponCode.isBlank() ? Optional.empty() : Optional.of(couponCode);
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderItemsCommand.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderItemsCommand.java
@@ -1,0 +1,20 @@
+package com.kaua.ecommerce.application.usecases.order.create;
+
+public record CreateOrderItemsCommand(
+        String productId,
+        String sku,
+        int quantity
+) {
+
+    public static CreateOrderItemsCommand with(
+            final String productId,
+            final String sku,
+            final int quantity
+    ) {
+        return new CreateOrderItemsCommand(
+                productId,
+                sku,
+                quantity
+        );
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderOutput.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderOutput.java
@@ -1,0 +1,10 @@
+package com.kaua.ecommerce.application.usecases.order.create;
+
+import com.kaua.ecommerce.domain.order.Order;
+
+public record CreateOrderOutput(String orderId, String orderCode) {
+
+    public static CreateOrderOutput from(final Order aOrder) {
+        return new CreateOrderOutput(aOrder.getId().getValue(), aOrder.getOrderCode().getValue());
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderUseCase.java
@@ -1,0 +1,9 @@
+package com.kaua.ecommerce.application.usecases.order.create;
+
+import com.kaua.ecommerce.application.UseCase;
+import com.kaua.ecommerce.application.either.Either;
+import com.kaua.ecommerce.domain.validation.handler.NotificationHandler;
+
+public abstract class CreateOrderUseCase extends
+        UseCase<Either<NotificationHandler, CreateOrderOutput>, CreateOrderCommand> {
+}

--- a/application/src/main/java/com/kaua/ecommerce/application/usecases/order/create/DefaultCreateOrderUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/usecases/order/create/DefaultCreateOrderUseCase.java
@@ -1,0 +1,188 @@
+package com.kaua.ecommerce.application.usecases.order.create;
+
+import com.kaua.ecommerce.application.adapters.TransactionManager;
+import com.kaua.ecommerce.application.either.Either;
+import com.kaua.ecommerce.application.exceptions.TransactionFailureException;
+import com.kaua.ecommerce.application.gateways.order.*;
+import com.kaua.ecommerce.domain.customer.Customer;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.exceptions.NotFoundException;
+import com.kaua.ecommerce.domain.order.*;
+import com.kaua.ecommerce.domain.validation.Error;
+import com.kaua.ecommerce.domain.validation.handler.NotificationHandler;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DefaultCreateOrderUseCase extends CreateOrderUseCase {
+
+    private final OrderGateway orderGateway;
+    private final OrderCouponGateway orderCouponGateway;
+    private final OrderCustomerGateway orderCustomerGateway;
+    private final OrderDeliveryGateway orderDeliveryGateway;
+    private final OrderPaymentGateway orderPaymentGateway;
+    private final OrderProductGateway orderProductGateway;
+    private final OrderFreightGateway orderFreightGateway;
+    private final TransactionManager transactionManager;
+
+    public DefaultCreateOrderUseCase(
+            final OrderGateway orderGateway,
+            final OrderCouponGateway orderCouponGateway,
+            final OrderCustomerGateway orderCustomerGateway,
+            final OrderDeliveryGateway orderDeliveryGateway,
+            final OrderPaymentGateway orderPaymentGateway,
+            final OrderProductGateway orderProductGateway,
+            final OrderFreightGateway orderFreightGateway,
+            final TransactionManager transactionManager
+    ) {
+        this.orderGateway = Objects.requireNonNull(orderGateway);
+        this.orderCouponGateway = Objects.requireNonNull(orderCouponGateway);
+        this.orderCustomerGateway = Objects.requireNonNull(orderCustomerGateway);
+        this.orderDeliveryGateway = Objects.requireNonNull(orderDeliveryGateway);
+        this.orderPaymentGateway = Objects.requireNonNull(orderPaymentGateway);
+        this.orderProductGateway = Objects.requireNonNull(orderProductGateway);
+        this.orderFreightGateway = Objects.requireNonNull(orderFreightGateway);
+        this.transactionManager = Objects.requireNonNull(transactionManager);
+    }
+
+    @Override
+    public Either<NotificationHandler, CreateOrderOutput> execute(CreateOrderCommand input) {
+        final var aNotification = NotificationHandler.create();
+
+        // In microservices, findByCustomerId call an external service and possible failure point
+        final var aCustomer = this.orderCustomerGateway.findByCustomerId(input.customerId())
+                .orElseThrow(NotFoundException.with(Customer.class, input.customerId()));
+
+        // In microservices, calculateFreight call an external service and possible failure point
+        final var aOrderProductDetails = getOrderProductsDetails(input);
+        final var aFreight = getCalculateFreight(aOrderProductDetails, aCustomer, input.freightType());
+
+        // In microservices, applyCoupon call an external service and possible failure point
+        final var aCoupon = input.getCouponCode().map(this.orderCouponGateway::applyCoupon);
+        final var aOrderDelivery = createOrderDelivery(aFreight, aCustomer);
+        final var aOrderPayment = createOrderPayment(input);
+
+        final var aOrderCode = OrderCode.create(this.orderGateway.count());
+        final var aCouponCode = aCoupon.map(OrderCouponGateway.OrderCouponApplyOutput::couponCode)
+                .orElse(null);
+        final var aCouponPercentage = aCoupon.map(OrderCouponGateway.OrderCouponApplyOutput::couponPercentage)
+                .orElse(0.0f);
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomer.customerId(),
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+        addOrderItems(input, aOrderProductDetails, aOrder);
+        aOrder.calculateTotalAmount(aOrderDelivery);
+
+        validateOrderComponents(aOrderDelivery, aNotification, aOrderPayment, aOrder);
+
+        if (aNotification.hasError()) {
+            return Either.left(aNotification);
+        }
+
+        final var aTransactionResult = this.transactionManager.execute(() -> {
+            this.orderGateway.createInBatch(aOrder.getOrderItems());
+            this.orderDeliveryGateway.create(aOrderDelivery);
+            this.orderPaymentGateway.create(aOrderPayment);
+            this.orderGateway.create(aOrder);
+            return aOrder;
+        });
+
+        if (aTransactionResult.isFailure()) {
+            throw TransactionFailureException.with(aTransactionResult.getErrorResult());
+        }
+
+        return Either.right(CreateOrderOutput.from(aOrder));
+    }
+
+    private Set<OrderProductGateway.OrderProductDetails> getOrderProductsDetails(CreateOrderCommand input) {
+        final var aResult = input.items().stream()
+                .map(it -> this.orderProductGateway.getProductDetailsBySku(it.sku()))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+
+        if (aResult.isEmpty() || aResult.size() != input.items().size()) {
+            throw DomainException.with(new Error("No product details found"));
+        }
+
+        return aResult;
+    }
+
+    private void addOrderItems(
+            final CreateOrderCommand input,
+            final Set<OrderProductGateway.OrderProductDetails> aOrderProductDetails,
+            final Order aOrder
+    ) {
+        input.items().forEach(it -> {
+            final var aDetail = aOrderProductDetails.stream()
+                    .filter(product -> product.sku().equals(it.sku()))
+                    .findFirst()
+                    .get();
+
+            final var aOrderItem = OrderItem.create(
+                    aOrder.getId().getValue(),
+                    it.productId(),
+                    it.sku(),
+                    it.quantity(),
+                    aDetail.price()
+            );
+
+            aOrder.addItem(aOrderItem);
+        });
+    }
+
+    private void validateOrderComponents(OrderDelivery aOrderDelivery, NotificationHandler aNotification, OrderPayment aOrderPayment, Order aOrder) {
+        aOrderDelivery.validate(aNotification);
+        aOrderPayment.validate(aNotification);
+        aOrder.validate(aNotification);
+    }
+
+    private OrderFreightGateway.OrderFreightDetails getCalculateFreight(
+            final Set<OrderProductGateway.OrderProductDetails> input,
+            final OrderCustomerGateway.OrderCustomerOutput aCustomer,
+            final String aFreightType
+    ) {
+        return this.orderFreightGateway.calculateFreight(new OrderFreightGateway.CalculateOrderFreightInput(
+                aCustomer.zipCode(),
+                aFreightType,
+                input.stream()
+                        .map(it -> new OrderFreightGateway.CalculateOrderFreightItemsInput(
+                                it.weight(),
+                                it.width(),
+                                it.height(),
+                                it.length()
+                        ))
+                        .collect(Collectors.toSet())
+        ));
+    }
+
+    private OrderPayment createOrderPayment(final CreateOrderCommand input) {
+        return OrderPayment.newOrderPayment(
+                input.paymentMethodId(),
+                input.installments()
+        );
+    }
+
+    private OrderDelivery createOrderDelivery(final OrderFreightGateway.OrderFreightDetails aFreight, final OrderCustomerGateway.OrderCustomerOutput aCustomer) {
+        return OrderDelivery.newOrderDelivery(
+                aFreight.type(),
+                aFreight.price(),
+                aFreight.deadlineInDays(),
+                aCustomer.street(),
+                aCustomer.number(),
+                aCustomer.complement(),
+                aCustomer.district(),
+                aCustomer.city(),
+                aCustomer.state(),
+                aCustomer.zipCode()
+        );
+    }
+}

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/freight/calculate/CalculateFreightUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/freight/calculate/CalculateFreightUseCaseTest.java
@@ -1,0 +1,142 @@
+package com.kaua.ecommerce.application.usecases.freight.calculate;
+
+import com.kaua.ecommerce.application.UseCaseTest;
+import com.kaua.ecommerce.application.gateways.FreightGateway;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.freight.Freight;
+import com.kaua.ecommerce.domain.freight.FreightType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+public class CalculateFreightUseCaseTest extends UseCaseTest {
+
+    @Mock
+    private FreightGateway freightGateway;
+
+    @InjectMocks
+    private DefaultCalculateFreightUseCase calculateFreightUseCase;
+
+    @Test
+    void givenAValidCommand_whenCallCalculateFreight_thenShouldReturnFreight() {
+        final var aZipCode = "12345678";
+        final var aType = "PAC";
+        final var aHeight = 15.0;
+        final var aWidth = 30.0;
+        final var aLength = 45.0;
+        final var aWeight = 55.5;
+
+        final var aFreight = Freight.newFreight(aZipCode, FreightType.PAC, 10.0f, 3);
+
+        final var aCommand = CalculateFreightCommand.with(
+                aZipCode,
+                aType,
+                Set.of(CalculateFreightItemsCommand.with(
+                        aHeight,
+                        aWidth,
+                        aLength,
+                        aWeight
+                ))
+        );
+
+        Mockito.when(this.freightGateway.calculateFreight(Mockito.any()))
+                .thenReturn(aFreight);
+
+        final var aOutput = this.calculateFreightUseCase.execute(aCommand);
+
+        Assertions.assertEquals(aFreight.getCep(), aOutput.getCep());
+        Assertions.assertEquals(aFreight.getType(), aOutput.getType());
+        Assertions.assertEquals(aFreight.getPrice(), aOutput.getPrice());
+        Assertions.assertEquals(aFreight.getDeadline(), aOutput.getDeadline());
+    }
+
+    @Test
+    void givenAValidCommandWithTwoProduct_whenCallCalculateFreight_thenShouldReturnFreight() {
+        final var aZipCode = "12345678";
+        final var aType = "PAC";
+        final var aHeight = 15.0;
+        final var aWidth = 30.0;
+        final var aLength = 45.0;
+        final var aWeight = 55.5;
+
+        final var aFreight = Freight.newFreight(aZipCode, FreightType.PAC, 10.0f, 3);
+
+        final var aCommand = CalculateFreightCommand.with(
+                aZipCode,
+                aType,
+                Set.of(CalculateFreightItemsCommand.with(
+                                aWeight,
+                                aWidth,
+                                aHeight,
+                                aLength
+                        ),
+                        CalculateFreightItemsCommand.with(
+                                35.5,
+                                40.0,
+                                55.0,
+                                65.5
+                        ))
+        );
+
+        Mockito.when(this.freightGateway.calculateFreight(Mockito.any()))
+                .thenReturn(aFreight);
+
+        final var aOutput = this.calculateFreightUseCase.execute(aCommand);
+
+        Assertions.assertEquals(aFreight.getCep(), aOutput.getCep());
+        Assertions.assertEquals(aFreight.getType(), aOutput.getType());
+        Assertions.assertEquals(aFreight.getPrice(), aOutput.getPrice());
+        Assertions.assertEquals(aFreight.getDeadline(), aOutput.getDeadline());
+    }
+
+    @Test
+    void givenAnInvalidType_whenCallCalculateFreight_thenShouldThrowDomainException() {
+        final var aZipCode = "12345678";
+        final var aType = "INVALID";
+        final var aHeight = 10.0;
+        final var aWidth = 10.0;
+        final var aLength = 10.0;
+        final var aWeight = 10.0;
+
+        final var expectedErrorMessage = "type %s was not found".formatted(aType);
+
+        final var aCommand = CalculateFreightCommand.with(
+                aZipCode,
+                aType,
+                Set.of(CalculateFreightItemsCommand.with(
+                        aHeight,
+                        aWidth,
+                        aLength,
+                        aWeight
+                ))
+        );
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> this.calculateFreightUseCase.execute(aCommand));
+
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenAnInvalidItems_whenCallCalculateFreight_thenShouldThrowDomainException() {
+        final var aZipCode = "12345678";
+        final var aType = "PAC";
+
+        final var expectedErrorMessage = "No item found to calculate freight";
+
+        final var aCommand = CalculateFreightCommand.with(
+                aZipCode,
+                aType,
+                Set.of()
+        );
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> this.calculateFreightUseCase.execute(aCommand));
+
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+}

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderUseCaseTest.java
@@ -1,0 +1,641 @@
+package com.kaua.ecommerce.application.usecases.order.create;
+
+import com.kaua.ecommerce.application.UseCaseTest;
+import com.kaua.ecommerce.application.adapters.TransactionManager;
+import com.kaua.ecommerce.application.adapters.responses.TransactionResult;
+import com.kaua.ecommerce.application.exceptions.TransactionFailureException;
+import com.kaua.ecommerce.application.gateways.order.*;
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.domain.coupon.Coupon;
+import com.kaua.ecommerce.domain.customer.Customer;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.exceptions.NotFoundException;
+import com.kaua.ecommerce.domain.order.OrderStatus;
+import com.kaua.ecommerce.domain.utils.IdUtils;
+import com.kaua.ecommerce.domain.validation.Error;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.argThat;
+
+public class CreateOrderUseCaseTest extends UseCaseTest {
+
+    @Mock
+    private OrderGateway orderGateway;
+
+    @Mock
+    private OrderCustomerGateway orderCustomerGateway;
+
+    @Mock
+    private OrderCouponGateway orderCouponGateway;
+
+    @Mock
+    private OrderDeliveryGateway orderDeliveryGateway;
+
+    @Mock
+    private OrderPaymentGateway orderPaymentGateway;
+
+    @Mock
+    private OrderProductGateway orderProductGateway;
+
+    @Mock
+    private OrderFreightGateway orderFreightGateway;
+
+    @Mock
+    private TransactionManager transactionManager;
+
+    @InjectMocks
+    private DefaultCreateOrderUseCase createOrderUseCase;
+
+    @Test
+    void givenAValidCommand_whenCallCreateOrderUseCase_thenShouldCreateOrder() {
+        final var aCustomer = Fixture.Customers.customerWithAllParams;
+        final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+
+        final var aCustomerId = aCustomer.getAccountId();
+        final var aCouponCode = aCoupon.getCode().getValue();
+        final var aFreightType = "SEDEX";
+        final var aPaymentMethodId = IdUtils.generateWithoutDash();
+        final var aInstallments = 0;
+        final var aItems = Set.of(
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "camiseta",
+                        5
+                ),
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "bola",
+                        50
+                )
+        );
+
+        final var aCommand = CreateOrderCommand.with(
+                aCustomerId,
+                aCouponCode,
+                aFreightType,
+                aPaymentMethodId,
+                aInstallments,
+                aItems
+        );
+
+        Mockito.when(orderCustomerGateway.findByCustomerId(aCustomerId))
+                .thenReturn(createOrderCustomerOutput(aCustomer));
+        Mockito.when(orderProductGateway.getProductDetailsBySku(Mockito.any()))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("camiseta", BigDecimal.valueOf(100.0))))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("bola", BigDecimal.valueOf(200.0))));
+        Mockito.when(orderFreightGateway.calculateFreight(Mockito.any()))
+                .thenReturn(createOrderFreightDetails());
+        Mockito.when(orderCouponGateway.applyCoupon(aCouponCode))
+                .thenReturn(createOrderCouponOutput(aCoupon));
+        Mockito.when(orderGateway.count())
+                .thenReturn(1L);
+        Mockito.when(orderGateway.createInBatch(Mockito.anySet()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(orderDeliveryGateway.create(Mockito.any()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(orderPaymentGateway.create(Mockito.any()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(orderGateway.create(Mockito.any()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(this.transactionManager.execute(Mockito.any()))
+                .thenAnswer(it -> TransactionResult.success(it.getArgument(0, Supplier.class).get()));
+
+        final var aOutput = this.createOrderUseCase.execute(aCommand).getRight();
+
+        Assertions.assertNotNull(aOutput);
+        Assertions.assertNotNull(aOutput.orderId());
+        Assertions.assertNotNull(aOutput.orderCode());
+
+        Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
+        Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
+        Mockito.verify(orderFreightGateway, Mockito.times(1)).calculateFreight(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(1)).applyCoupon(aCouponCode);
+        Mockito.verify(orderGateway, Mockito.times(1)).count();
+        Mockito.verify(orderGateway, Mockito.times(1))
+                .createInBatch(argThat(it -> it.size() == aItems.size()));
+        Mockito.verify(orderDeliveryGateway, Mockito.times(1)).create(Mockito.any());
+        Mockito.verify(orderPaymentGateway, Mockito.times(1)).create(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(1)).create(argThat(it ->
+                Objects.nonNull(it.getId())
+                        && Objects.nonNull(it.getOrderCode())
+                        && Objects.equals(it.getCustomerId(), aCustomerId)
+                        && Objects.equals(it.getCouponCode().get(), aCouponCode)
+                        && Objects.equals(it.getCouponPercentage(), aCoupon.getPercentage())
+                        && Objects.equals(it.getOrderItems().size(), aItems.size())
+                        && Objects.equals(it.getOrderStatus(), OrderStatus.WAITING_PAYMENT)
+                        && Objects.nonNull(it.getOrderDeliveryId())
+                        && Objects.nonNull(it.getOrderPaymentId())
+                        && it.getTotalAmount().compareTo(BigDecimal.ZERO) >= 0
+                        && Objects.nonNull(it.getCreatedAt())
+                        && Objects.nonNull(it.getUpdatedAt())));
+    }
+
+    @Test
+    void givenAValidCommandWithNullCouponCode_whenCallCreateOrderUseCase_thenShouldCreateOrder() {
+        final var aCustomer = Fixture.Customers.customerWithAllParams;
+
+        final var aCustomerId = aCustomer.getAccountId();
+        final String aCouponCode = null;
+        final var aFreightType = "SEDEX";
+        final var aPaymentMethodId = IdUtils.generateWithoutDash();
+        final var aInstallments = 0;
+        final var aItems = Set.of(
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "camiseta",
+                        5
+                ),
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "bola",
+                        50
+                )
+        );
+
+        final var aCommand = CreateOrderCommand.with(
+                aCustomerId,
+                aCouponCode,
+                aFreightType,
+                aPaymentMethodId,
+                aInstallments,
+                aItems
+        );
+
+        Mockito.when(orderCustomerGateway.findByCustomerId(aCustomerId))
+                .thenReturn(createOrderCustomerOutput(aCustomer));
+        Mockito.when(orderProductGateway.getProductDetailsBySku(Mockito.any()))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("camiseta", BigDecimal.valueOf(100.0))))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("bola", BigDecimal.valueOf(200.0))));
+        Mockito.when(orderFreightGateway.calculateFreight(Mockito.any()))
+                .thenReturn(createOrderFreightDetails());
+        Mockito.when(orderGateway.count())
+                .thenReturn(1L);
+        Mockito.when(orderGateway.createInBatch(Mockito.anySet()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(orderDeliveryGateway.create(Mockito.any()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(orderPaymentGateway.create(Mockito.any()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(orderGateway.create(Mockito.any()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(this.transactionManager.execute(Mockito.any()))
+                .thenAnswer(it -> TransactionResult.success(it.getArgument(0, Supplier.class).get()));
+
+        final var aOutput = this.createOrderUseCase.execute(aCommand).getRight();
+
+        Assertions.assertNotNull(aOutput);
+        Assertions.assertNotNull(aOutput.orderId());
+        Assertions.assertNotNull(aOutput.orderCode());
+
+        Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
+        Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
+        Mockito.verify(orderFreightGateway, Mockito.times(1)).calculateFreight(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(1)).count();
+        Mockito.verify(orderGateway, Mockito.times(1))
+                .createInBatch(argThat(it -> it.size() == aItems.size()));
+        Mockito.verify(orderDeliveryGateway, Mockito.times(1)).create(Mockito.any());
+        Mockito.verify(orderPaymentGateway, Mockito.times(1)).create(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(1)).create(argThat(it ->
+                Objects.nonNull(it.getId())
+                        && Objects.nonNull(it.getOrderCode())
+                        && Objects.equals(it.getCustomerId(), aCustomerId)
+                        && it.getCouponCode().isEmpty()
+                        && Objects.equals(it.getCouponPercentage(), 0.0f)
+                        && Objects.equals(it.getOrderItems().size(), aItems.size())
+                        && Objects.equals(it.getOrderStatus(), OrderStatus.WAITING_PAYMENT)
+                        && Objects.nonNull(it.getOrderDeliveryId())
+                        && Objects.nonNull(it.getOrderPaymentId())
+                        && it.getTotalAmount().compareTo(BigDecimal.ZERO) >= 0
+                        && Objects.nonNull(it.getCreatedAt())
+                        && Objects.nonNull(it.getUpdatedAt())));
+    }
+
+    @Test
+    void givenAValidCommandWithEmptyCouponCode_whenCallCreateOrderUseCase_thenShouldCreateOrder() {
+        final var aCustomer = Fixture.Customers.customerWithAllParams;
+
+        final var aCustomerId = aCustomer.getAccountId();
+        final String aCouponCode = "";
+        final var aFreightType = "SEDEX";
+        final var aPaymentMethodId = IdUtils.generateWithoutDash();
+        final var aInstallments = 0;
+        final var aItems = Set.of(
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "camiseta",
+                        5
+                ),
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "bola",
+                        50
+                )
+        );
+
+        final var aCommand = CreateOrderCommand.with(
+                aCustomerId,
+                aCouponCode,
+                aFreightType,
+                aPaymentMethodId,
+                aInstallments,
+                aItems
+        );
+
+        Mockito.when(orderCustomerGateway.findByCustomerId(aCustomerId))
+                .thenReturn(createOrderCustomerOutput(aCustomer));
+        Mockito.when(orderProductGateway.getProductDetailsBySku(Mockito.any()))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("camiseta", BigDecimal.valueOf(100.0))))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("bola", BigDecimal.valueOf(200.0))));
+        Mockito.when(orderFreightGateway.calculateFreight(Mockito.any()))
+                .thenReturn(createOrderFreightDetails());
+        Mockito.when(orderGateway.count())
+                .thenReturn(1L);
+        Mockito.when(orderGateway.createInBatch(Mockito.anySet()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(orderDeliveryGateway.create(Mockito.any()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(orderPaymentGateway.create(Mockito.any()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(orderGateway.create(Mockito.any()))
+                .thenAnswer(returnsFirstArg());
+        Mockito.when(this.transactionManager.execute(Mockito.any()))
+                .thenAnswer(it -> TransactionResult.success(it.getArgument(0, Supplier.class).get()));
+
+        final var aOutput = this.createOrderUseCase.execute(aCommand).getRight();
+
+        Assertions.assertNotNull(aOutput);
+        Assertions.assertNotNull(aOutput.orderId());
+        Assertions.assertNotNull(aOutput.orderCode());
+
+        Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
+        Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
+        Mockito.verify(orderFreightGateway, Mockito.times(1)).calculateFreight(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(1)).count();
+        Mockito.verify(orderGateway, Mockito.times(1))
+                .createInBatch(argThat(it -> it.size() == aItems.size()));
+        Mockito.verify(orderDeliveryGateway, Mockito.times(1)).create(Mockito.any());
+        Mockito.verify(orderPaymentGateway, Mockito.times(1)).create(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(1)).create(argThat(it ->
+                Objects.nonNull(it.getId())
+                        && Objects.nonNull(it.getOrderCode())
+                        && Objects.equals(it.getCustomerId(), aCustomerId)
+                        && it.getCouponCode().isEmpty()
+                        && Objects.equals(it.getCouponPercentage(), 0.0f)
+                        && Objects.equals(it.getOrderItems().size(), aItems.size())
+                        && Objects.equals(it.getOrderStatus(), OrderStatus.WAITING_PAYMENT)
+                        && Objects.nonNull(it.getOrderDeliveryId())
+                        && Objects.nonNull(it.getOrderPaymentId())
+                        && it.getTotalAmount().compareTo(BigDecimal.ZERO) >= 0
+                        && Objects.nonNull(it.getCreatedAt())
+                        && Objects.nonNull(it.getUpdatedAt())));
+    }
+
+    @Test
+    void givenAValidCommand_whenCallCreateOrderUseCaseButTransactionFailure_shouldThrowTransactionFailureException() {
+        final var aCustomer = Fixture.Customers.customerWithAllParams;
+        final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+
+        final var aCustomerId = aCustomer.getAccountId();
+        final var aCouponCode = aCoupon.getCode().getValue();
+        final var aFreightType = "SEDEX";
+        final var aPaymentMethodId = IdUtils.generateWithoutDash();
+        final var aInstallments = 0;
+        final var aItems = Set.of(
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "camiseta",
+                        5
+                ),
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "bola",
+                        50
+                )
+        );
+
+        final var expectedErrorMessage = "Error on create order";
+
+        final var aCommand = CreateOrderCommand.with(
+                aCustomerId,
+                aCouponCode,
+                aFreightType,
+                aPaymentMethodId,
+                aInstallments,
+                aItems
+        );
+
+        Mockito.when(orderCustomerGateway.findByCustomerId(aCustomerId))
+                .thenReturn(createOrderCustomerOutput(aCustomer));
+        Mockito.when(orderProductGateway.getProductDetailsBySku(Mockito.any()))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("camiseta", BigDecimal.valueOf(100.0))))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("bola", BigDecimal.valueOf(200.0))));
+        Mockito.when(orderFreightGateway.calculateFreight(Mockito.any()))
+                .thenReturn(createOrderFreightDetails());
+        Mockito.when(orderCouponGateway.applyCoupon(aCouponCode))
+                .thenReturn(createOrderCouponOutput(aCoupon));
+        Mockito.when(orderGateway.count())
+                .thenReturn(1L);
+        Mockito.when(transactionManager.execute(Mockito.any()))
+                .thenReturn(TransactionResult.failure(new Error(expectedErrorMessage)));
+
+        final var aException = Assertions.assertThrows(TransactionFailureException.class,
+                () -> this.createOrderUseCase.execute(aCommand));
+
+        Assertions.assertNotNull(aException);
+        Assertions.assertEquals(expectedErrorMessage, aException.getMessage());
+
+        Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
+        Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
+        Mockito.verify(orderFreightGateway, Mockito.times(1)).calculateFreight(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(1)).applyCoupon(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(1)).count();
+        Mockito.verify(orderGateway, Mockito.times(0)).createInBatch(Mockito.any());
+        Mockito.verify(orderDeliveryGateway, Mockito.times(0)).create(Mockito.any());
+        Mockito.verify(orderPaymentGateway, Mockito.times(0)).create(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(0)).create(Mockito.any());
+    }
+
+    @Test
+    void givenInvalidCommand_whenCallCreateOrderUseCase_shouldReturnNotificationHandler() {
+        final var aCustomer = Fixture.Customers.customerWithAllParams;
+        final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+
+        final var aCustomerId = " ";
+        final var aCouponCode = aCoupon.getCode().getValue();
+        final var aFreightType = "SEDEX";
+        final var aPaymentMethodId = " ";
+        final var aInstallments = 0;
+        final var aItems = Set.of(
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "camiseta",
+                        5
+                ),
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "bola",
+                        50
+                )
+        );
+
+        final var aCommand = CreateOrderCommand.with(
+                aCustomerId,
+                aCouponCode,
+                aFreightType,
+                aPaymentMethodId,
+                aInstallments,
+                aItems
+        );
+
+        Mockito.when(orderCustomerGateway.findByCustomerId(aCustomerId))
+                .thenReturn(createOrderCustomerOutput(aCustomer));
+        Mockito.when(orderProductGateway.getProductDetailsBySku(Mockito.any()))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("camiseta", BigDecimal.valueOf(100.0))))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("bola", BigDecimal.valueOf(200.0))));
+        Mockito.when(orderFreightGateway.calculateFreight(Mockito.any()))
+                .thenReturn(createOrderFreightDetails());
+        Mockito.when(orderCouponGateway.applyCoupon(aCouponCode))
+                .thenReturn(createOrderCouponOutput(aCoupon));
+        Mockito.when(orderGateway.count())
+                .thenReturn(1L);
+
+        final var aOutput = this.createOrderUseCase.execute(aCommand).getLeft();
+
+        Assertions.assertNotNull(aOutput);
+        Assertions.assertTrue(aOutput.hasError());
+        Assertions.assertEquals(1, aOutput.getErrors().size());
+
+        Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
+        Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
+        Mockito.verify(orderFreightGateway, Mockito.times(1)).calculateFreight(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(1)).applyCoupon(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(1)).count();
+        Mockito.verify(orderGateway, Mockito.times(0)).createInBatch(Mockito.any());
+        Mockito.verify(orderDeliveryGateway, Mockito.times(0)).create(Mockito.any());
+        Mockito.verify(orderPaymentGateway, Mockito.times(0)).create(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(0)).create(Mockito.any());
+    }
+
+    @Test
+    void givenInvalidCustomerId_whenCallCreateOrderUseCase_shouldThrowNotFoundException() {
+        final var aCustomer = Fixture.Customers.customerWithAllParams;
+        final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+
+        final var aCustomerId = aCustomer.getAccountId();
+        final var aCouponCode = aCoupon.getCode().getValue();
+        final var aFreightType = "SEDEX";
+        final var aPaymentMethodId = IdUtils.generateWithoutDash();
+        final var aInstallments = 0;
+        final var aItems = Set.of(
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "camiseta",
+                        5
+                ),
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "bola",
+                        50
+                )
+        );
+
+        final var aCommand = CreateOrderCommand.with(
+                aCustomerId,
+                aCouponCode,
+                aFreightType,
+                aPaymentMethodId,
+                aInstallments,
+                aItems
+        );
+
+        Mockito.when(orderCustomerGateway.findByCustomerId(aCustomerId))
+                .thenReturn(Optional.empty());
+
+        final var aException = Assertions.assertThrows(NotFoundException.class,
+                () -> this.createOrderUseCase.execute(aCommand));
+
+        Assertions.assertNotNull(aException);
+        Assertions.assertEquals(Fixture.notFoundMessage(Customer.class, aCustomerId), aException.getMessage());
+
+        Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
+        Mockito.verify(orderProductGateway, Mockito.times(0)).getProductDetailsBySku(Mockito.any());
+        Mockito.verify(orderFreightGateway, Mockito.times(0)).calculateFreight(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(0)).count();
+        Mockito.verify(orderGateway, Mockito.times(0)).createInBatch(Mockito.any());
+        Mockito.verify(orderDeliveryGateway, Mockito.times(0)).create(Mockito.any());
+        Mockito.verify(orderPaymentGateway, Mockito.times(0)).create(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(0)).create(Mockito.any());
+    }
+
+    @Test
+    void givenAnInvalidAllSkus_whenCallCreateOrderUseCase_shouldThrowDomainException() {
+        final var aCustomer = Fixture.Customers.customerWithAllParams;
+        final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+
+        final var aCustomerId = aCustomer.getAccountId();
+        final var aCouponCode = aCoupon.getCode().getValue();
+        final var aFreightType = "SEDEX";
+        final var aPaymentMethodId = IdUtils.generateWithoutDash();
+        final var aInstallments = 0;
+        final var aItems = Set.of(
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "camiseta",
+                        5
+                ),
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "bola",
+                        50
+                )
+        );
+
+        final var expectedErrorCount = 1;
+        final var expectedErrorMessage = "No product details found";
+
+        final var aCommand = CreateOrderCommand.with(
+                aCustomerId,
+                aCouponCode,
+                aFreightType,
+                aPaymentMethodId,
+                aInstallments,
+                aItems
+        );
+
+        Mockito.when(orderCustomerGateway.findByCustomerId(aCustomerId))
+                .thenReturn(createOrderCustomerOutput(aCustomer));
+        Mockito.when(orderProductGateway.getProductDetailsBySku(Mockito.any()))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.empty());
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> this.createOrderUseCase.execute(aCommand));
+
+        Assertions.assertEquals(expectedErrorCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+
+        Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
+        Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
+        Mockito.verify(orderFreightGateway, Mockito.times(0)).calculateFreight(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(0)).count();
+        Mockito.verify(orderGateway, Mockito.times(0)).createInBatch(Mockito.any());
+        Mockito.verify(orderDeliveryGateway, Mockito.times(0)).create(Mockito.any());
+        Mockito.verify(orderPaymentGateway, Mockito.times(0)).create(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(0)).create(Mockito.any());
+    }
+
+    @Test
+    void givenInvalidOneSku_whenCallCreateOrderUseCase_shouldThrowDomainException() {
+        final var aCustomer = Fixture.Customers.customerWithAllParams;
+        final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+
+        final var aCustomerId = aCustomer.getAccountId();
+        final var aCouponCode = aCoupon.getCode().getValue();
+        final var aFreightType = "SEDEX";
+        final var aPaymentMethodId = IdUtils.generateWithoutDash();
+        final var aInstallments = 0;
+        final var aItems = Set.of(
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "camiseta",
+                        5
+                ),
+                CreateOrderItemsCommand.with(
+                        IdUtils.generateWithoutDash(),
+                        "bola",
+                        50
+                )
+        );
+
+        final var expectedErrorCount = 1;
+        final var expectedErrorMessage = "No product details found";
+
+        final var aCommand = CreateOrderCommand.with(
+                aCustomerId,
+                aCouponCode,
+                aFreightType,
+                aPaymentMethodId,
+                aInstallments,
+                aItems
+        );
+
+        Mockito.when(orderCustomerGateway.findByCustomerId(aCustomerId))
+                .thenReturn(createOrderCustomerOutput(aCustomer));
+        Mockito.when(orderProductGateway.getProductDetailsBySku(Mockito.any()))
+                .thenReturn(Optional.of(createOrderProductDetailsOutput("camiseta", BigDecimal.valueOf(100.0))))
+                .thenReturn(Optional.empty());
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> this.createOrderUseCase.execute(aCommand));
+
+        Assertions.assertEquals(expectedErrorCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+
+        Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
+        Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
+        Mockito.verify(orderFreightGateway, Mockito.times(0)).calculateFreight(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(0)).count();
+        Mockito.verify(orderGateway, Mockito.times(0)).createInBatch(Mockito.any());
+        Mockito.verify(orderDeliveryGateway, Mockito.times(0)).create(Mockito.any());
+        Mockito.verify(orderPaymentGateway, Mockito.times(0)).create(Mockito.any());
+        Mockito.verify(orderGateway, Mockito.times(0)).create(Mockito.any());
+    }
+
+    private OrderCouponGateway.OrderCouponApplyOutput createOrderCouponOutput(final Coupon aCoupon) {
+        return new OrderCouponGateway.OrderCouponApplyOutput(
+                aCoupon.getId().getValue(),
+                aCoupon.getCode().getValue(),
+                aCoupon.getPercentage()
+        );
+    }
+
+    private Optional<OrderCustomerGateway.OrderCustomerOutput> createOrderCustomerOutput(final Customer aCustomer) {
+        return Optional.of(
+                new OrderCustomerGateway.OrderCustomerOutput(
+                        aCustomer.getAccountId(),
+                        aCustomer.getAddress().get().getZipCode(),
+                        aCustomer.getAddress().get().getStreet(),
+                        aCustomer.getAddress().get().getNumber(),
+                        aCustomer.getAddress().get().getComplement(),
+                        aCustomer.getAddress().get().getDistrict(),
+                        aCustomer.getAddress().get().getCity(),
+                        aCustomer.getAddress().get().getState()
+                )
+        );
+    }
+
+    private OrderFreightGateway.OrderFreightDetails createOrderFreightDetails() {
+        return new OrderFreightGateway.OrderFreightDetails(
+                "PAC",
+                10.0f,
+                5
+        );
+    }
+
+    private OrderProductGateway.OrderProductDetails createOrderProductDetailsOutput(String sku, BigDecimal price) {
+        return new OrderProductGateway.OrderProductDetails(
+                sku,
+                price,
+                15.0,
+                30.0,
+                10.0,
+                0.5
+        );
+    }
+}

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/product/media/upload/UploadProductImageUseCaseTest.java
@@ -13,7 +13,7 @@ import com.kaua.ecommerce.domain.product.ProductImage;
 import com.kaua.ecommerce.domain.product.ProductImageResource;
 import com.kaua.ecommerce.domain.product.ProductImageType;
 import com.kaua.ecommerce.domain.product.ProductStatus;
-import com.kaua.ecommerce.domain.utils.Resource;
+import com.kaua.ecommerce.domain.resource.Resource;
 import com.kaua.ecommerce.domain.validation.Error;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/domain/src/main/java/com/kaua/ecommerce/domain/exceptions/NotAcceptDuplicatedItemsException.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/exceptions/NotAcceptDuplicatedItemsException.java
@@ -1,0 +1,16 @@
+package com.kaua.ecommerce.domain.exceptions;
+
+import java.util.Collections;
+
+public class NotAcceptDuplicatedItemsException extends DomainException {
+
+    private NotAcceptDuplicatedItemsException(String aMessage) {
+        super(aMessage, Collections.emptyList());
+    }
+
+    public static NotAcceptDuplicatedItemsException with(final String aSku) {
+        return new NotAcceptDuplicatedItemsException(
+                String.format("The item with SKU %s is already in the order", aSku)
+        );
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/Order.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/Order.java
@@ -1,0 +1,239 @@
+package com.kaua.ecommerce.domain.order;
+
+import com.kaua.ecommerce.domain.AggregateRoot;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.exceptions.NotAcceptDuplicatedItemsException;
+import com.kaua.ecommerce.domain.order.identifiers.OrderDeliveryID;
+import com.kaua.ecommerce.domain.order.identifiers.OrderID;
+import com.kaua.ecommerce.domain.order.identifiers.OrderPaymentID;
+import com.kaua.ecommerce.domain.order.validations.OrderValidation;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import com.kaua.ecommerce.domain.utils.InstantUtils;
+import com.kaua.ecommerce.domain.validation.Error;
+import com.kaua.ecommerce.domain.validation.ValidationHandler;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public class Order extends AggregateRoot<OrderID> {
+
+    private final OrderCode orderCode;
+    private final OrderStatus orderStatus;
+    private final Set<OrderItem> orderItems;
+    private final String customerId;
+    private final String couponCode;
+    private final float couponPercentage;
+    private final OrderDeliveryID orderDeliveryId;
+    private final OrderPaymentID orderPaymentId;
+    private final Instant createdAt;
+    private BigDecimal totalAmount;
+    private Instant updatedAt;
+
+    private Order(
+            final OrderID aOrderID,
+            final long aVersion,
+            final OrderCode aOrderCode,
+            final OrderStatus aOrderStatus,
+            final Set<OrderItem> aOrderItems,
+            final BigDecimal aTotalAmount,
+            final String aCustomerId,
+            final String aCouponCode,
+            final float aCouponPercentage,
+            final OrderDeliveryID aOrderDeliveryId,
+            final OrderPaymentID aOrderPaymentId,
+            final Instant aCreatedAt,
+            final Instant aUpdatedAt
+    ) {
+        super(aOrderID, aVersion);
+        this.orderCode = aOrderCode;
+        this.orderStatus = aOrderStatus;
+        this.orderItems = aOrderItems;
+        this.totalAmount = aTotalAmount;
+        this.customerId = aCustomerId;
+        this.couponCode = aCouponCode;
+        this.couponPercentage = aCouponPercentage;
+        this.orderDeliveryId = aOrderDeliveryId;
+        this.orderPaymentId = aOrderPaymentId;
+        this.createdAt = aCreatedAt;
+        this.updatedAt = aUpdatedAt;
+    }
+
+    public static Order newOrder(
+            final OrderCode aOrderCode,
+            final String aCustomerId,
+            final String aCouponCode,
+            final float aCouponPercentage,
+            final OrderDelivery aOrderDelivery,
+            final OrderPaymentID aOrderPaymentId
+    ) {
+        final var aOrderId = OrderID.unique();
+        final var aNow = InstantUtils.now();
+
+        if (aOrderDelivery == null) {
+            throw DomainException.with(new Error(CommonErrorMessage.nullMessage("orderDeliveryId")));
+        }
+
+        return new Order(
+                aOrderId,
+                0,
+                aOrderCode,
+                OrderStatus.WAITING_PAYMENT,
+                new HashSet<>(),
+                BigDecimal.ZERO,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery.getId(),
+                aOrderPaymentId,
+                aNow,
+                aNow
+        );
+    }
+
+    public static Order with(
+            final String aOrderId,
+            final long aVersion,
+            final String aOrderCode,
+            final OrderStatus aOrderStatus,
+            final Set<OrderItem> aOrderItems,
+            final BigDecimal aTotalAmount,
+            final String aCustomerId,
+            final String aCouponCode,
+            final float aCouponPercentage,
+            final String aOrderDeliveryId,
+            final String aOrderPaymentId,
+            final Instant aCreatedAt,
+            final Instant aUpdatedAt
+    ) {
+        return new Order(
+                OrderID.from(aOrderId),
+                aVersion,
+                OrderCode.with(aOrderCode),
+                aOrderStatus,
+                aOrderItems,
+                aTotalAmount,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                OrderDeliveryID.from(aOrderDeliveryId),
+                OrderPaymentID.from(aOrderPaymentId),
+                aCreatedAt,
+                aUpdatedAt
+        );
+    }
+
+    public static Order with(final Order aOrder) {
+        return new Order(
+                aOrder.getId(),
+                aOrder.getVersion(),
+                aOrder.getOrderCode(),
+                aOrder.getOrderStatus(),
+                aOrder.getOrderItems(),
+                aOrder.getTotalAmount(),
+                aOrder.getCustomerId(),
+                aOrder.getCouponCode().orElse(null),
+                aOrder.getCouponPercentage(),
+                aOrder.getOrderDeliveryId(),
+                aOrder.getOrderPaymentId(),
+                aOrder.getCreatedAt(),
+                aOrder.getUpdatedAt()
+        );
+    }
+
+    public void calculateTotalAmount(final OrderDelivery aOrderDelivery) {
+        this.totalAmount = this.orderItems.stream()
+                .map(OrderItem::getTotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        this.totalAmount = this.totalAmount.add(BigDecimal.valueOf(aOrderDelivery.getFreightPrice()));
+
+        if (this.getCouponCode().isPresent()) {
+            this.totalAmount = this.totalAmount.subtract(this.totalAmount
+                    .multiply(BigDecimal.valueOf(this.couponPercentage / 100)));
+        }
+    }
+
+    public void addItem(final OrderItem aOrderItem) {
+        this.orderItems.stream()
+                .filter(it -> it.getSku().equals(aOrderItem.getSku()))
+                .findFirst()
+                .ifPresentOrElse(
+                        it -> {
+                            throw NotAcceptDuplicatedItemsException.with(aOrderItem.getSku());
+                        },
+                        () -> this.orderItems.add(aOrderItem));
+    }
+
+    @Override
+    public void validate(ValidationHandler handler) {
+        new OrderValidation(handler, this).validate();
+    }
+
+    public OrderCode getOrderCode() {
+        return orderCode;
+    }
+
+    public OrderStatus getOrderStatus() {
+        return orderStatus;
+    }
+
+    public Set<OrderItem> getOrderItems() {
+        return Collections.unmodifiableSet(orderItems);
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public Optional<String> getCouponCode() {
+        return Optional.ofNullable(couponCode);
+    }
+
+    public float getCouponPercentage() {
+        return couponPercentage;
+    }
+
+    public OrderDeliveryID getOrderDeliveryId() {
+        return orderDeliveryId;
+    }
+
+    public OrderPaymentID getOrderPaymentId() {
+        return orderPaymentId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public BigDecimal getTotalAmount() {
+        return totalAmount.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "Order(" +
+                "id=" + getId().getValue() +
+                ", orderCode=" + orderCode.getValue() +
+                ", orderStatus=" + orderStatus.name() +
+                ", orderItems=" + orderItems.size() +
+                ", customerId='" + customerId + '\'' +
+                ", couponCode='" + getCouponCode().orElse(null) + '\'' +
+                ", couponPercentage=" + couponPercentage +
+                ", orderDeliveryId=" + orderDeliveryId.getValue() +
+                ", orderPaymentId=" + orderPaymentId.getValue() +
+                ", totalAmount=" + getTotalAmount() +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", version=" + getVersion() +
+                ')';
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/OrderCode.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/OrderCode.java
@@ -1,0 +1,36 @@
+package com.kaua.ecommerce.domain.order;
+
+import com.kaua.ecommerce.domain.ValueObject;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import com.kaua.ecommerce.domain.validation.Error;
+
+import java.time.LocalDateTime;
+
+public class OrderCode extends ValueObject {
+
+    private final String value;
+
+    private OrderCode(final String value) {
+        if (value == null || value.isBlank()) {
+            throw DomainException.with(new Error(CommonErrorMessage.nullOrBlank("orderCode")));
+        }
+        this.value = value;
+    }
+
+    public static OrderCode create(final long sequence) {
+        final var aNow = LocalDateTime.now();
+        final var aYear = aNow.getYear();
+        final var aSequenceFormattedWithEightZero = String.format("%09d", sequence + 1);
+        final var aCode = String.format("%d%s", aYear, aSequenceFormattedWithEightZero);
+        return new OrderCode(aCode);
+    }
+
+    public static OrderCode with(final String value) {
+        return new OrderCode(value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/OrderDelivery.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/OrderDelivery.java
@@ -1,0 +1,149 @@
+package com.kaua.ecommerce.domain.order;
+
+import com.kaua.ecommerce.domain.AggregateRoot;
+import com.kaua.ecommerce.domain.order.identifiers.OrderDeliveryID;
+import com.kaua.ecommerce.domain.order.validations.OrderDeliveryValidation;
+import com.kaua.ecommerce.domain.validation.ValidationHandler;
+
+import java.util.Optional;
+
+public class OrderDelivery extends AggregateRoot<OrderDeliveryID> {
+
+    private final String freightType;
+    private final float freightPrice;
+    private final int deliveryEstimated;
+    private final String street;
+    private final String number;
+    private final String complement;
+    private final String district;
+    private final String city;
+    private final String state;
+    private final String zipCode;
+
+    private OrderDelivery(
+            final OrderDeliveryID aOrderDeliveryID,
+            final String aFreightType,
+            final float aFreightPrice,
+            final int aDeliveryEstimated,
+            final String aStreet,
+            final String aNumber,
+            final String aComplement,
+            final String aDistrict,
+            final String aCity,
+            final String aState,
+            final String aZipCode
+    ) {
+        super(aOrderDeliveryID);
+        this.freightType = aFreightType;
+        this.freightPrice = aFreightPrice;
+        this.deliveryEstimated = aDeliveryEstimated;
+        this.street = aStreet;
+        this.number = aNumber;
+        this.complement = aComplement;
+        this.district = aDistrict;
+        this.city = aCity;
+        this.state = aState;
+        this.zipCode = aZipCode;
+    }
+
+    public static OrderDelivery newOrderDelivery(
+            final String aFreightType,
+            final float aFreightPrice,
+            final int aDeliveryEstimated,
+            final String aStreet,
+            final String aNumber,
+            final String aComplement,
+            final String aDistrict,
+            final String aCity,
+            final String aState,
+            final String aZipCode
+    ) {
+        final var aOrderDeliveryId = OrderDeliveryID.unique();
+        return new OrderDelivery(
+                aOrderDeliveryId,
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+    }
+
+    public static OrderDelivery with(
+            final String aOrderDeliveryId,
+            final String aFreightType,
+            final float aFreightPrice,
+            final int aDeliveryEstimated,
+            final String aStreet,
+            final String aNumber,
+            final String aComplement,
+            final String aDistrict,
+            final String aCity,
+            final String aState,
+            final String aZipCode
+    ) {
+        return new OrderDelivery(
+                OrderDeliveryID.from(aOrderDeliveryId),
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+    }
+
+    @Override
+    public void validate(ValidationHandler handler) {
+        new OrderDeliveryValidation(handler, this).validate();
+    }
+
+    public String getFreightType() {
+        return freightType;
+    }
+
+    public float getFreightPrice() {
+        return freightPrice;
+    }
+
+    public int getDeliveryEstimated() {
+        return deliveryEstimated;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public Optional<String> getComplement() {
+        return Optional.ofNullable(complement);
+    }
+
+    public String getDistrict() {
+        return district;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public String getZipCode() {
+        return zipCode;
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/OrderItem.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/OrderItem.java
@@ -1,0 +1,131 @@
+package com.kaua.ecommerce.domain.order;
+
+import com.kaua.ecommerce.domain.ValueObject;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import com.kaua.ecommerce.domain.utils.IdUtils;
+import com.kaua.ecommerce.domain.validation.Error;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public class OrderItem extends ValueObject {
+
+    private final String orderItemId;
+    private final String orderId;
+    private final String productId;
+    private final String sku;
+    private final int quantity;
+    private final BigDecimal price;
+
+    private OrderItem(
+            final String aOrderItemId,
+            final String aOrderId,
+            final String aProductId,
+            final String aSku,
+            final int aQuantity,
+            final BigDecimal aPrice
+    ) {
+        this.orderItemId = aOrderItemId;
+        this.orderId = aOrderId;
+        this.productId = aProductId;
+        this.sku = aSku;
+        this.quantity = aQuantity;
+        this.price = aPrice;
+        selfValidate();
+    }
+
+    public static OrderItem create(
+            final String aOrderId,
+            final String aProductId,
+            final String aSku,
+            final int aQuantity,
+            final BigDecimal aPrice
+    ) {
+        return new OrderItem(
+                IdUtils.generate(),
+                aOrderId,
+                aProductId,
+                aSku,
+                aQuantity,
+                aPrice
+        );
+    }
+
+    public static OrderItem with(
+            final String aOrderItemId,
+            final String aOrderId,
+            final String aProductId,
+            final String aSku,
+            final int aQuantity,
+            final BigDecimal aPrice
+    ) {
+        return new OrderItem(
+                aOrderItemId,
+                aOrderId,
+                aProductId,
+                aSku,
+                aQuantity,
+                aPrice
+        );
+    }
+
+    private void selfValidate() {
+        if (orderId == null || orderId.isBlank()) {
+            throw DomainException.with(new Error(CommonErrorMessage.nullOrBlank("orderId")));
+        }
+        if (productId == null || productId.isBlank()) {
+            throw DomainException.with(new Error(CommonErrorMessage.nullOrBlank("productId")));
+        }
+        if (sku == null || sku.isBlank()) {
+            throw DomainException.with(new Error(CommonErrorMessage.nullOrBlank("sku")));
+        }
+        if (quantity <= 0) {
+            throw DomainException.with(new Error(CommonErrorMessage.greaterThan("quantity", 0)));
+        }
+        if (price == null || price.compareTo(BigDecimal.ZERO) <= 0) {
+            throw DomainException.with(new Error(CommonErrorMessage.greaterThan("price", 0)));
+        }
+    }
+
+    public BigDecimal getTotal() {
+        return price.multiply(BigDecimal.valueOf(quantity));
+    }
+
+    public String getOrderItemId() {
+        return orderItemId;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public String getSku() {
+        return sku;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final OrderItem orderItem = (OrderItem) o;
+        return Objects.equals(getOrderItemId(), orderItem.getOrderItemId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getOrderItemId());
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/OrderPayment.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/OrderPayment.java
@@ -1,0 +1,59 @@
+package com.kaua.ecommerce.domain.order;
+
+import com.kaua.ecommerce.domain.AggregateRoot;
+import com.kaua.ecommerce.domain.order.identifiers.OrderPaymentID;
+import com.kaua.ecommerce.domain.order.validations.OrderPaymentValidation;
+import com.kaua.ecommerce.domain.validation.ValidationHandler;
+
+public class OrderPayment extends AggregateRoot<OrderPaymentID> {
+
+    private final String paymentMethodId;
+    private final int installments;
+
+    private OrderPayment(
+            final OrderPaymentID aOrderPaymentId,
+            final String aPaymentMethodId,
+            final int aInstallments
+    ) {
+        super(aOrderPaymentId);
+        this.paymentMethodId = aPaymentMethodId;
+        this.installments = aInstallments;
+    }
+
+    public static OrderPayment newOrderPayment(
+            final String aPaymentMethodId,
+            final int aInstallments
+    ) {
+        final var aOrderPaymentId = OrderPaymentID.unique();
+        return new OrderPayment(
+                aOrderPaymentId,
+                aPaymentMethodId,
+                aInstallments
+        );
+    }
+
+    public static OrderPayment with(
+            final String aOrderPaymentId,
+            final String aPaymentMethodId,
+            final int aInstallments
+    ) {
+        return new OrderPayment(
+                OrderPaymentID.from(aOrderPaymentId),
+                aPaymentMethodId,
+                aInstallments
+        );
+    }
+
+    @Override
+    public void validate(ValidationHandler handler) {
+        new OrderPaymentValidation(handler, this).validate();
+    }
+
+    public String getPaymentMethodId() {
+        return paymentMethodId;
+    }
+
+    public int getInstallments() {
+        return installments;
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/OrderStatus.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/OrderStatus.java
@@ -1,0 +1,19 @@
+package com.kaua.ecommerce.domain.order;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum OrderStatus {
+
+    WAITING_PAYMENT,
+    PAID,
+    DELIVERED,
+    SENT,
+    CANCELED;
+
+    public static Optional<OrderStatus> of(final String value) {
+        return Arrays.stream(values())
+                .filter(it -> it.name().equalsIgnoreCase(value))
+                .findFirst();
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/identifiers/OrderDeliveryID.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/identifiers/OrderDeliveryID.java
@@ -1,0 +1,41 @@
+package com.kaua.ecommerce.domain.order.identifiers;
+
+import com.kaua.ecommerce.domain.Identifier;
+import com.kaua.ecommerce.domain.utils.IdUtils;
+
+import java.util.Objects;
+
+public class OrderDeliveryID extends Identifier {
+
+    private final String value;
+
+    private OrderDeliveryID(final String value) {
+        this.value = Objects.requireNonNull(value, "'id' should not be null");
+    }
+
+    public static OrderDeliveryID unique() {
+        return new OrderDeliveryID(IdUtils.generate());
+    }
+
+    public static OrderDeliveryID from(final String value) {
+        return new OrderDeliveryID(value);
+    }
+
+    @Override
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final OrderDeliveryID orderID = (OrderDeliveryID) o;
+        return Objects.equals(getValue(), orderID.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/identifiers/OrderID.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/identifiers/OrderID.java
@@ -1,0 +1,41 @@
+package com.kaua.ecommerce.domain.order.identifiers;
+
+import com.kaua.ecommerce.domain.Identifier;
+import com.kaua.ecommerce.domain.utils.IdUtils;
+
+import java.util.Objects;
+
+public class OrderID extends Identifier {
+
+    private final String value;
+
+    private OrderID(final String value) {
+        this.value = Objects.requireNonNull(value, "'id' should not be null");
+    }
+
+    public static OrderID unique() {
+        return new OrderID(IdUtils.generate());
+    }
+
+    public static OrderID from(final String value) {
+        return new OrderID(value);
+    }
+
+    @Override
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final OrderID orderID = (OrderID) o;
+        return Objects.equals(getValue(), orderID.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/identifiers/OrderPaymentID.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/identifiers/OrderPaymentID.java
@@ -1,0 +1,41 @@
+package com.kaua.ecommerce.domain.order.identifiers;
+
+import com.kaua.ecommerce.domain.Identifier;
+import com.kaua.ecommerce.domain.utils.IdUtils;
+
+import java.util.Objects;
+
+public class OrderPaymentID extends Identifier {
+
+    private final String value;
+
+    private OrderPaymentID(final String value) {
+        this.value = Objects.requireNonNull(value, "'id' should not be null");
+    }
+
+    public static OrderPaymentID unique() {
+        return new OrderPaymentID(IdUtils.generate());
+    }
+
+    public static OrderPaymentID from(final String value) {
+        return new OrderPaymentID(value);
+    }
+
+    @Override
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final OrderPaymentID orderID = (OrderPaymentID) o;
+        return Objects.equals(getValue(), orderID.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/validations/OrderDeliveryValidation.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/validations/OrderDeliveryValidation.java
@@ -1,0 +1,91 @@
+package com.kaua.ecommerce.domain.order.validations;
+
+import com.kaua.ecommerce.domain.order.OrderDelivery;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import com.kaua.ecommerce.domain.validation.Error;
+import com.kaua.ecommerce.domain.validation.ValidationHandler;
+import com.kaua.ecommerce.domain.validation.Validator;
+
+public class OrderDeliveryValidation extends Validator {
+
+    private final OrderDelivery orderDelivery;
+
+    public OrderDeliveryValidation(final ValidationHandler handler, final OrderDelivery orderDelivery) {
+        super(handler);
+        this.orderDelivery = orderDelivery;
+    }
+
+    @Override
+    public void validate() {
+        checkFreightTypeConstraints();
+        checkFreightPriceConstraints();
+        checkDeliveryEstimatedConstraints();
+        checkStreetConstraints();
+        checkNumberConstraints();
+        checkComplementConstraints();
+        checkDistrictConstraints();
+        checkCityConstraints();
+        checkStateConstraints();
+        checkZipCodeConstraints();
+    }
+
+    private void checkFreightTypeConstraints() {
+        if (this.orderDelivery.getFreightType() == null || this.orderDelivery.getFreightType().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.nullOrBlank("freightType")));
+        }
+    }
+
+    private void checkFreightPriceConstraints() {
+        if (this.orderDelivery.getFreightPrice() <= 0) {
+            this.validationHandler().append(new Error(CommonErrorMessage.greaterThan("freightPrice", 0)));
+        }
+    }
+
+    private void checkDeliveryEstimatedConstraints() {
+        if (this.orderDelivery.getDeliveryEstimated() <= 0) {
+            this.validationHandler().append(new Error(CommonErrorMessage.greaterThan("deliveryEstimated", 0)));
+        }
+    }
+
+    private void checkStreetConstraints() {
+        if (this.orderDelivery.getStreet() == null || this.orderDelivery.getStreet().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.nullOrBlank("street")));
+        }
+    }
+
+    private void checkNumberConstraints() {
+        if (this.orderDelivery.getNumber() == null || this.orderDelivery.getNumber().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.nullOrBlank("number")));
+        }
+    }
+
+    private void checkComplementConstraints() {
+        if (this.orderDelivery.getComplement().isPresent() && this.orderDelivery.getComplement().get().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.blankMessage("complement")));
+        }
+    }
+
+    private void checkDistrictConstraints() {
+        if (this.orderDelivery.getDistrict() == null || this.orderDelivery.getDistrict().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.nullOrBlank("district")));
+        }
+    }
+
+    private void checkCityConstraints() {
+        if (this.orderDelivery.getCity() == null || this.orderDelivery.getCity().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.nullOrBlank("city")));
+        }
+    }
+
+    private void checkStateConstraints() {
+        if (this.orderDelivery.getState() == null || this.orderDelivery.getState().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.nullOrBlank("state")));
+        }
+    }
+
+    private void checkZipCodeConstraints() {
+        if (this.orderDelivery.getZipCode() == null || this.orderDelivery.getZipCode().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.nullOrBlank("zipCode")));
+        }
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/validations/OrderPaymentValidation.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/validations/OrderPaymentValidation.java
@@ -1,0 +1,35 @@
+package com.kaua.ecommerce.domain.order.validations;
+
+import com.kaua.ecommerce.domain.order.OrderPayment;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import com.kaua.ecommerce.domain.validation.Error;
+import com.kaua.ecommerce.domain.validation.ValidationHandler;
+import com.kaua.ecommerce.domain.validation.Validator;
+
+public class OrderPaymentValidation extends Validator {
+
+    private final OrderPayment orderPayment;
+
+    public OrderPaymentValidation(final ValidationHandler handler, final OrderPayment orderPayment) {
+        super(handler);
+        this.orderPayment = orderPayment;
+    }
+
+    @Override
+    public void validate() {
+        checkPaymentMethodIdConstraints();
+        checkInstallmentsConstraints();
+    }
+
+    private void checkPaymentMethodIdConstraints() {
+        if (this.orderPayment.getPaymentMethodId() == null || this.orderPayment.getPaymentMethodId().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.nullOrBlank("paymentMethodId")));
+        }
+    }
+
+    private void checkInstallmentsConstraints() {
+        if (this.orderPayment.getInstallments() < 0) {
+            this.validationHandler().append(new Error(CommonErrorMessage.greaterThan("installments", -1)));
+        }
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/validations/OrderValidation.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/validations/OrderValidation.java
@@ -1,0 +1,65 @@
+package com.kaua.ecommerce.domain.order.validations;
+
+import com.kaua.ecommerce.domain.order.Order;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import com.kaua.ecommerce.domain.validation.Error;
+import com.kaua.ecommerce.domain.validation.ValidationHandler;
+import com.kaua.ecommerce.domain.validation.Validator;
+
+import java.math.BigDecimal;
+
+public class OrderValidation extends Validator {
+
+    private final Order order;
+
+    public OrderValidation(final ValidationHandler handler, final Order order) {
+        super(handler);
+        this.order = order;
+    }
+
+    @Override
+    public void validate() {
+        checkCustomerIdConstraints();
+        checkCouponCodeConstraints();
+        checkCouponPercentageConstraints();
+        checkOrderPaymentIdConstraints();
+        checkOrderItemsConstraints();
+        checkOrderTotalAmountConstraints();
+    }
+
+    private void checkCustomerIdConstraints() {
+        if (this.order.getCustomerId() == null || this.order.getCustomerId().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.nullOrBlank("customerId")));
+        }
+    }
+
+    private void checkCouponCodeConstraints() {
+        if (this.order.getCouponCode().isPresent() && this.order.getCouponCode().get().isBlank()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.blankMessage("couponCode")));
+        }
+    }
+
+    private void checkCouponPercentageConstraints() {
+        if (this.order.getCouponPercentage() < 0) {
+            this.validationHandler().append(new Error(CommonErrorMessage.greaterThan("couponPercentage", -1)));
+        }
+    }
+
+    private void checkOrderPaymentIdConstraints() {
+        if (this.order.getOrderPaymentId() == null) {
+            this.validationHandler().append(new Error(CommonErrorMessage.nullMessage("orderPaymentId")));
+        }
+    }
+
+    private void checkOrderItemsConstraints() {
+        if (this.order.getOrderItems().isEmpty()) {
+            this.validationHandler().append(new Error(CommonErrorMessage.minSize("orderItems", 1)));
+        }
+    }
+
+    private void checkOrderTotalAmountConstraints() {
+        if (this.order.getTotalAmount().compareTo(BigDecimal.ZERO) <= 0) {
+            this.validationHandler().append(new Error(CommonErrorMessage.greaterThan("totalAmount", 0)));
+        }
+    }
+}

--- a/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductImageResource.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/product/ProductImageResource.java
@@ -1,7 +1,7 @@
 package com.kaua.ecommerce.domain.product;
 
 import com.kaua.ecommerce.domain.ValueObject;
-import com.kaua.ecommerce.domain.utils.Resource;
+import com.kaua.ecommerce.domain.resource.Resource;
 
 import java.util.Objects;
 

--- a/domain/src/main/java/com/kaua/ecommerce/domain/resource/Resource.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/resource/Resource.java
@@ -1,4 +1,4 @@
-package com.kaua.ecommerce.domain.utils;
+package com.kaua.ecommerce.domain.resource;
 
 import com.kaua.ecommerce.domain.ValueObject;
 

--- a/domain/src/main/java/com/kaua/ecommerce/domain/utils/CommonErrorMessage.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/utils/CommonErrorMessage.java
@@ -13,12 +13,20 @@ public final class CommonErrorMessage {
         return "'" + fieldName + "' should not be null";
     }
 
+    public static String blankMessage(final String fieldName) {
+        return "'" + fieldName + "' should not be blank";
+    }
+
     public static String lengthBetween(final String fieldName, final int min, final int max) {
         return "'" + fieldName + "' must be between " + min + " and " + max + " characters";
     }
 
     public static String maxSize(final String fieldName, final int max) {
         return "'" + fieldName + "' must be less than " + max + " characters";
+    }
+
+    public static String minSize(final String fieldName, final int min) {
+        return "'" + fieldName + "' must be greater than " + min + " characters";
     }
 
     public static String greaterThan(final String fieldName, final int value) {

--- a/domain/src/test/java/com/kaua/ecommerce/domain/Fixture.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/Fixture.java
@@ -18,7 +18,7 @@ import com.kaua.ecommerce.domain.inventory.movement.InventoryMovementStatus;
 import com.kaua.ecommerce.domain.product.*;
 import com.kaua.ecommerce.domain.utils.IdUtils;
 import com.kaua.ecommerce.domain.utils.InstantUtils;
-import com.kaua.ecommerce.domain.utils.Resource;
+import com.kaua.ecommerce.domain.resource.Resource;
 import net.datafaker.Faker;
 
 import java.math.BigDecimal;

--- a/domain/src/test/java/com/kaua/ecommerce/domain/Fixture.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/Fixture.java
@@ -11,14 +11,18 @@ import com.kaua.ecommerce.domain.customer.CustomerID;
 import com.kaua.ecommerce.domain.customer.Telephone;
 import com.kaua.ecommerce.domain.customer.address.Address;
 import com.kaua.ecommerce.domain.exceptions.NotFoundException;
+import com.kaua.ecommerce.domain.freight.Freight;
+import com.kaua.ecommerce.domain.freight.FreightType;
 import com.kaua.ecommerce.domain.inventory.Inventory;
 import com.kaua.ecommerce.domain.inventory.InventoryID;
 import com.kaua.ecommerce.domain.inventory.movement.InventoryMovement;
 import com.kaua.ecommerce.domain.inventory.movement.InventoryMovementStatus;
+import com.kaua.ecommerce.domain.order.*;
+import com.kaua.ecommerce.domain.order.identifiers.OrderPaymentID;
 import com.kaua.ecommerce.domain.product.*;
+import com.kaua.ecommerce.domain.resource.Resource;
 import com.kaua.ecommerce.domain.utils.IdUtils;
 import com.kaua.ecommerce.domain.utils.InstantUtils;
-import com.kaua.ecommerce.domain.resource.Resource;
 import net.datafaker.Faker;
 
 import java.math.BigDecimal;
@@ -357,6 +361,126 @@ public final class Fixture {
         public static CouponSlot generateValidCouponSlot(final Coupon aCoupon) {
             return CouponSlot.newCouponSlot(
                     aCoupon.getId().getValue()
+            );
+        }
+    }
+
+    public static final class Freights {
+        private Freights() {
+        }
+
+        public static Freight freightPAC() {
+            return Freight.newFreight(
+                    faker.address().zipCode(),
+                    FreightType.PAC,
+                    10.0f,
+                    5
+            );
+        }
+    }
+
+    public static final class Orders {
+        private static final OrderDelivery ORDER_DELIVERY = OrderDelivery.newOrderDelivery(
+                "PAC",
+                25.0f,
+                10,
+                "Rua Teste",
+                "123",
+                null,
+                "Bairro Teste",
+                "Cidade Teste",
+                "Estado Teste",
+                "12345678"
+        );
+
+        private static final OrderPayment ORDER_PAYMENT_WITH_ZERO_INSTALLMENTS = OrderPayment.newOrderPayment(
+                IdUtils.generateWithoutDash(),
+                0
+        );
+
+        private static final Order ORDER_WITH_COUPON = Order.newOrder(
+                OrderCode.create(faker.random().nextLong(0, 999999)),
+                IdUtils.generate(),
+                "coupon-code",
+                10.0f,
+                ORDER_DELIVERY,
+                OrderPaymentID.unique()
+        );
+        private static final OrderItem ORDER_ITEM = OrderItem.create(
+                ORDER_WITH_COUPON.getId().getValue(),
+                "product-id",
+                Fixture.createSku(faker.book().title()),
+                10,
+                BigDecimal.valueOf(100.0)
+        );
+        private static final Order ORDER_WITHOUT_COUPON = Order.newOrder(
+                OrderCode.create(faker.random().nextLong(0, 999999)),
+                IdUtils.generate(),
+                null,
+                0.0f,
+                ORDER_DELIVERY,
+                OrderPaymentID.unique()
+        );
+
+        private Orders() {
+        }
+
+        public static Order orderWithCoupon() {
+            ORDER_WITH_COUPON.addItem(OrderItem.create(
+                    ORDER_WITH_COUPON.getId().getValue(),
+                    "product-id",
+                    Fixture.createSku(faker.book().title()),
+                    10,
+                    BigDecimal.valueOf(100.0)
+            ));
+            ORDER_WITH_COUPON.calculateTotalAmount(ORDER_DELIVERY);
+            return Order.with(ORDER_WITH_COUPON);
+        }
+
+        public static Order orderWithoutCoupon() {
+            ORDER_WITHOUT_COUPON.addItem(OrderItem.create(
+                    ORDER_WITHOUT_COUPON.getId().getValue(),
+                    "product-id",
+                    Fixture.createSku(faker.book().title()),
+                    10,
+                    BigDecimal.valueOf(100.0)
+            ));
+            ORDER_WITHOUT_COUPON.calculateTotalAmount(ORDER_DELIVERY);
+            return Order.with(ORDER_WITHOUT_COUPON);
+        }
+
+        public static OrderDelivery orderDelivery() {
+            return OrderDelivery.with(
+                    ORDER_DELIVERY.getId().getValue(),
+                    ORDER_DELIVERY.getFreightType(),
+                    ORDER_DELIVERY.getFreightPrice(),
+                    ORDER_DELIVERY.getDeliveryEstimated(),
+                    ORDER_DELIVERY.getStreet(),
+                    ORDER_DELIVERY.getNumber(),
+                    ORDER_DELIVERY.getComplement().orElse(null),
+                    ORDER_DELIVERY.getDistrict(),
+                    ORDER_DELIVERY.getCity(),
+                    ORDER_DELIVERY.getState(),
+                    ORDER_DELIVERY.getZipCode()
+            );
+        }
+
+        public static OrderPayment orderPaymentWithZeroInstallments() {
+            return OrderPayment.with(
+                    ORDER_PAYMENT_WITH_ZERO_INSTALLMENTS.getId().getValue(),
+                    ORDER_PAYMENT_WITH_ZERO_INSTALLMENTS.getPaymentMethodId(),
+                    ORDER_PAYMENT_WITH_ZERO_INSTALLMENTS.getInstallments()
+            );
+        }
+
+        public static OrderItem orderItem() {
+            return OrderItem.with(
+                    ORDER_ITEM.getOrderItemId(),
+                    ORDER_ITEM.getOrderId(),
+                    ORDER_ITEM.getProductId(),
+                    ORDER_ITEM.getSku(),
+                    ORDER_ITEM.getQuantity(),
+                    ORDER_ITEM.getPrice()
             );
         }
     }

--- a/domain/src/test/java/com/kaua/ecommerce/domain/order/OrderDeliveryTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/order/OrderDeliveryTest.java
@@ -1,0 +1,103 @@
+package com.kaua.ecommerce.domain.order;
+
+import com.kaua.ecommerce.domain.UnitTest;
+import com.kaua.ecommerce.domain.order.identifiers.OrderDeliveryID;
+import com.kaua.ecommerce.domain.validation.handler.ThrowsValidationHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OrderDeliveryTest extends UnitTest {
+
+    @Test
+    void givenAValidValues_whenCallNewOrderDelivery_shouldCreateNewOrderDelivery() {
+        final var aFreightType = "sedex";
+        final var aFreightPrice = 5.0F;
+        final var aFreightDays = 5;
+        final var aStreet = "aStreet";
+        final var aNumber = "235";
+        final String aComplement = null;
+        final var aDistrict = "aDistrict";
+        final var aCity = "aCity";
+        final var aState = "aState";
+        final var aZipCode = "aZipCode";
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aFreightDays,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        Assertions.assertNotNull(aOrderDelivery);
+        Assertions.assertEquals(aFreightType, aOrderDelivery.getFreightType());
+        Assertions.assertEquals(aFreightPrice, aOrderDelivery.getFreightPrice());
+        Assertions.assertEquals(aFreightDays, aOrderDelivery.getDeliveryEstimated());
+        Assertions.assertEquals(aStreet, aOrderDelivery.getStreet());
+        Assertions.assertEquals(aNumber, aOrderDelivery.getNumber());
+        Assertions.assertTrue(aOrderDelivery.getComplement().isEmpty());
+        Assertions.assertEquals(aCity, aOrderDelivery.getCity());
+        Assertions.assertEquals(aState, aOrderDelivery.getState());
+        Assertions.assertEquals(aZipCode, aOrderDelivery.getZipCode());
+        Assertions.assertDoesNotThrow(() -> aOrderDelivery.validate(new ThrowsValidationHandler()));
+    }
+
+    @Test
+    void givenAValidValues_whenCallOrderDeliveryWith_shouldRestoreOrderDelivery() {
+        final var aOrderDeliveryId = "aOrderDeliveryId";
+        final var aFreightType = "sedex";
+        final var aFreightPrice = 5.0F;
+        final var aFreightDays = 5;
+        final var aStreet = "aStreet";
+        final var aNumber = "235";
+        final String aComplement = null;
+        final var aDistrict = "aDistrict";
+        final var aCity = "aCity";
+        final var aState = "aState";
+        final var aZipCode = "aZipCode";
+
+        final var aOrderDelivery = OrderDelivery.with(
+                aOrderDeliveryId,
+                aFreightType,
+                aFreightPrice,
+                aFreightDays,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        Assertions.assertNotNull(aOrderDelivery);
+        Assertions.assertEquals(aOrderDeliveryId, aOrderDelivery.getId().getValue());
+        Assertions.assertEquals(aFreightType, aOrderDelivery.getFreightType());
+        Assertions.assertEquals(aFreightPrice, aOrderDelivery.getFreightPrice());
+        Assertions.assertEquals(aFreightDays, aOrderDelivery.getDeliveryEstimated());
+        Assertions.assertEquals(aStreet, aOrderDelivery.getStreet());
+        Assertions.assertEquals(aNumber, aOrderDelivery.getNumber());
+        Assertions.assertTrue(aOrderDelivery.getComplement().isEmpty());
+        Assertions.assertEquals(aCity, aOrderDelivery.getCity());
+        Assertions.assertEquals(aState, aOrderDelivery.getState());
+        Assertions.assertEquals(aZipCode, aOrderDelivery.getZipCode());
+        Assertions.assertDoesNotThrow(() -> aOrderDelivery.validate(new ThrowsValidationHandler()));
+    }
+
+    @Test
+    void testOrderDeliveryIdEqualsAndHashCode() {
+        final var aOrderDeliveryId = OrderDeliveryID.from("123456789");
+        final var anotherOrderDeliveryId = OrderDeliveryID.from("123456789");
+
+        Assertions.assertTrue(aOrderDeliveryId.equals(anotherOrderDeliveryId));
+        Assertions.assertTrue(aOrderDeliveryId.equals(aOrderDeliveryId));
+        Assertions.assertFalse(aOrderDeliveryId.equals(null));
+        Assertions.assertFalse(aOrderDeliveryId.equals(""));
+        Assertions.assertEquals(aOrderDeliveryId.hashCode(), anotherOrderDeliveryId.hashCode());
+    }
+}

--- a/domain/src/test/java/com/kaua/ecommerce/domain/order/OrderItemTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/order/OrderItemTest.java
@@ -1,0 +1,306 @@
+package com.kaua.ecommerce.domain.order;
+
+import com.kaua.ecommerce.domain.UnitTest;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.order.identifiers.OrderID;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+public class OrderItemTest extends UnitTest {
+
+    @Test
+    void givenAValidValues_whenCallCreate_shouldCreateNewOrderItem() {
+        final var aOrderId = OrderID.unique().getValue();
+        final var aProductId = "aProductId";
+        final var aSku = "aSku";
+        final var aQuantity = 1;
+        final var aPrice = BigDecimal.valueOf(10.0);
+
+        final var aOrderItem = OrderItem.create(
+                aOrderId,
+                aProductId,
+                aSku,
+                aQuantity,
+                aPrice
+        );
+
+        Assertions.assertNotNull(aOrderItem);
+        Assertions.assertEquals(aOrderId, aOrderItem.getOrderId());
+        Assertions.assertEquals(aProductId, aOrderItem.getProductId());
+        Assertions.assertEquals(aSku, aOrderItem.getSku());
+        Assertions.assertEquals(aQuantity, aOrderItem.getQuantity());
+        Assertions.assertEquals(aPrice, aOrderItem.getPrice());
+        Assertions.assertEquals(BigDecimal.valueOf(10.0), aOrderItem.getTotal());
+    }
+
+    @Test
+    void givenAValidValues_whenCallWith_shouldRestoreOrderItem() {
+        final var aOrderId = OrderID.unique().getValue();
+        final var aOrderItemId = "aOrderItemId";
+        final var aProductId = "aProductId";
+        final var aSku = "aSku";
+        final var aQuantity = 1;
+        final var aPrice = BigDecimal.valueOf(10.0);
+
+        final var aOrderItem = OrderItem.with(
+                aOrderItemId,
+                aOrderId,
+                aProductId,
+                aSku,
+                aQuantity,
+                aPrice
+        );
+
+        Assertions.assertNotNull(aOrderItem);
+        Assertions.assertEquals(aOrderItemId, aOrderItem.getOrderItemId());
+        Assertions.assertEquals(aOrderId, aOrderItem.getOrderId());
+        Assertions.assertEquals(aProductId, aOrderItem.getProductId());
+        Assertions.assertEquals(aSku, aOrderItem.getSku());
+        Assertions.assertEquals(aQuantity, aOrderItem.getQuantity());
+        Assertions.assertEquals(aPrice, aOrderItem.getPrice());
+        Assertions.assertEquals(BigDecimal.valueOf(10.0), aOrderItem.getTotal());
+    }
+
+    @Test
+    void testOrderItemIdEqualsAndHashCode() {
+        final var aOrderItemId = OrderItem.with(
+                "123456789",
+                "aOrderId",
+                "aProductId",
+                "aSku",
+                1,
+                BigDecimal.valueOf(10.0));
+        final var anotherOrderItemId = OrderItem.with(
+                "123456789",
+                "aOrderId",
+                "aProductId",
+                "aSku",
+                1,
+                BigDecimal.valueOf(10.0));
+
+        Assertions.assertTrue(aOrderItemId.equals(anotherOrderItemId));
+        Assertions.assertTrue(aOrderItemId.equals(aOrderItemId));
+        Assertions.assertFalse(aOrderItemId.equals(null));
+        Assertions.assertFalse(aOrderItemId.equals(""));
+        Assertions.assertEquals(aOrderItemId.hashCode(), anotherOrderItemId.hashCode());
+    }
+
+    @Test
+    void givenInvalidNullProductId_whenCallCreate_shouldThrowDomainException() {
+        final var aOrderId = OrderID.unique().getValue();
+        final String aProductId = null;
+        final var aSku = "aSku";
+        final var aQuantity = 1;
+        final var aPrice = BigDecimal.valueOf(10.0);
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("productId");
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderItem.create(
+                        aOrderId,
+                        aProductId,
+                        aSku,
+                        aQuantity,
+                        aPrice
+                ));
+
+        Assertions.assertEquals(expectedErrorsCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankProductId_whenCallCreate_shouldThrowDomainException() {
+        final var aOrderId = OrderID.unique().getValue();
+        final String aProductId = "";
+        final var aSku = "aSku";
+        final var aQuantity = 1;
+        final var aPrice = BigDecimal.valueOf(10.0);
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("productId");
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderItem.create(
+                        aOrderId,
+                        aProductId,
+                        aSku,
+                        aQuantity,
+                        aPrice
+                ));
+
+        Assertions.assertEquals(expectedErrorsCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankSku_whenCallCreate_shouldThrowDomainException() {
+        final var aOrderId = OrderID.unique().getValue();
+        final var aProductId = "aProductId";
+        final String aSku = "";
+        final var aQuantity = 1;
+        final var aPrice = BigDecimal.valueOf(10.0);
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("sku");
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderItem.create(
+                        aOrderId,
+                        aProductId,
+                        aSku,
+                        aQuantity,
+                        aPrice
+                ));
+
+        Assertions.assertEquals(expectedErrorsCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullSku_whenCallCreate_shouldThrowDomainException() {
+        final var aOrderId = OrderID.unique().getValue();
+        final var aProductId = "aProductId";
+        final String aSku = null;
+        final var aQuantity = 1;
+        final var aPrice = BigDecimal.valueOf(10.0);
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("sku");
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderItem.create(
+                        aOrderId,
+                        aProductId,
+                        aSku,
+                        aQuantity,
+                        aPrice
+                ));
+
+        Assertions.assertEquals(expectedErrorsCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNegativeQuantity_whenCallCreate_shouldThrowDomainException() {
+        final var aOrderId = OrderID.unique().getValue();
+        final var aProductId = "aProductId";
+        final var aSku = "aSku";
+        final var aQuantity = -1;
+        final var aPrice = BigDecimal.valueOf(10.0);
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.greaterThan("quantity", 0);
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderItem.create(
+                        aOrderId,
+                        aProductId,
+                        aSku,
+                        aQuantity,
+                        aPrice
+                ));
+
+        Assertions.assertEquals(expectedErrorsCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullPrice_whenCallCreate_shouldThrowDomainException() {
+        final var aOrderId = OrderID.unique().getValue();
+        final var aProductId = "aProductId";
+        final var aSku = "aSku";
+        final var aQuantity = 1;
+        final BigDecimal aPrice = null;
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.greaterThan("price", 0);
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderItem.create(
+                        aOrderId,
+                        aProductId,
+                        aSku,
+                        aQuantity,
+                        aPrice
+                ));
+
+        Assertions.assertEquals(expectedErrorsCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidZeroPrice_whenCallCreate_shouldThrowDomainException() {
+        final var aOrderId = OrderID.unique().getValue();
+        final var aProductId = "aProductId";
+        final var aSku = "aSku";
+        final var aQuantity = 1;
+        final var aPrice = BigDecimal.ZERO;
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.greaterThan("price", 0);
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderItem.create(
+                        aOrderId,
+                        aProductId,
+                        aSku,
+                        aQuantity,
+                        aPrice
+                ));
+
+        Assertions.assertEquals(expectedErrorsCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullOrderId_whenCallCreate_shouldThrowDomainException() {
+        final String aOrderId = null;
+        final var aProductId = "aProductId";
+        final var aSku = "aSku";
+        final var aQuantity = 1;
+        final var aPrice = BigDecimal.valueOf(10.0);
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("orderId");
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderItem.create(
+                        aOrderId,
+                        aProductId,
+                        aSku,
+                        aQuantity,
+                        aPrice
+                ));
+
+        Assertions.assertEquals(expectedErrorsCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankOrderId_whenCallCreate_shouldThrowDomainException() {
+        final String aOrderId = "";
+        final var aProductId = "aProductId";
+        final var aSku = "aSku";
+        final var aQuantity = 1;
+        final var aPrice = BigDecimal.valueOf(10.0);
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("orderId");
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderItem.create(
+                        aOrderId,
+                        aProductId,
+                        aSku,
+                        aQuantity,
+                        aPrice
+                ));
+
+        Assertions.assertEquals(expectedErrorsCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+}

--- a/domain/src/test/java/com/kaua/ecommerce/domain/order/OrderPaymentTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/order/OrderPaymentTest.java
@@ -1,0 +1,58 @@
+package com.kaua.ecommerce.domain.order;
+
+import com.kaua.ecommerce.domain.UnitTest;
+import com.kaua.ecommerce.domain.order.identifiers.OrderID;
+import com.kaua.ecommerce.domain.order.identifiers.OrderPaymentID;
+import com.kaua.ecommerce.domain.validation.handler.ThrowsValidationHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OrderPaymentTest extends UnitTest {
+
+    @Test
+    void givenAValidValues_whenCallNewOrderPayment_shouldCreateNewOrderPayment() {
+        final var aPaymentMethodId = "aPaymentMethodId";
+        final var aInstallments = 0;
+
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                aPaymentMethodId,
+                aInstallments
+        );
+
+        Assertions.assertNotNull(aOrderPayment);
+        Assertions.assertEquals(aPaymentMethodId, aOrderPayment.getPaymentMethodId());
+        Assertions.assertEquals(aInstallments, aOrderPayment.getInstallments());
+        Assertions.assertDoesNotThrow(() -> aOrderPayment.validate(new ThrowsValidationHandler()));
+    }
+
+    @Test
+    void givenAValidValues_whenCallOrderPaymentWith_shouldRestoreOrderPayment() {
+        final var aOrderPaymentId = "aOrderPaymentId";
+        final var aPaymentMethodId = "aPaymentMethodId";
+        final var aInstallments = 0;
+
+        final var aOrderPayment = OrderPayment.with(
+                aOrderPaymentId,
+                aPaymentMethodId,
+                aInstallments
+        );
+
+        Assertions.assertNotNull(aOrderPayment);
+        Assertions.assertEquals(aOrderPaymentId, aOrderPayment.getId().getValue());
+        Assertions.assertEquals(aPaymentMethodId, aOrderPayment.getPaymentMethodId());
+        Assertions.assertEquals(aInstallments, aOrderPayment.getInstallments());
+        Assertions.assertDoesNotThrow(() -> aOrderPayment.validate(new ThrowsValidationHandler()));
+    }
+
+    @Test
+    void testOrderPaymentIdEqualsAndHashCode() {
+        final var aOrderPaymentId = OrderPaymentID.from("123456789");
+        final var anotherOrderPaymentId = OrderPaymentID.from("123456789");
+
+        Assertions.assertTrue(aOrderPaymentId.equals(anotherOrderPaymentId));
+        Assertions.assertTrue(aOrderPaymentId.equals(aOrderPaymentId));
+        Assertions.assertFalse(aOrderPaymentId.equals(null));
+        Assertions.assertFalse(aOrderPaymentId.equals(""));
+        Assertions.assertEquals(aOrderPaymentId.hashCode(), anotherOrderPaymentId.hashCode());
+    }
+}

--- a/domain/src/test/java/com/kaua/ecommerce/domain/order/OrderTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/order/OrderTest.java
@@ -1,0 +1,336 @@
+package com.kaua.ecommerce.domain.order;
+
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.domain.UnitTest;
+import com.kaua.ecommerce.domain.order.identifiers.OrderID;
+import com.kaua.ecommerce.domain.utils.InstantUtils;
+import com.kaua.ecommerce.domain.validation.handler.ThrowsValidationHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+public class OrderTest extends UnitTest {
+
+    @Test
+    void givenAValidValues_whenCallNewOrder_shouldCreateNewOrder() {
+        final var aSequence = 0;
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+
+        final var aItemOne = OrderItem.create(
+                aOrder.getId().getValue(),
+                "aProductId",
+                "aSkuOne",
+                1,
+                BigDecimal.valueOf(10.0)
+        );
+        final var aItemTwo = OrderItem.create(
+                aOrder.getId().getValue(),
+                "aProductId",
+                "aSkuTwo",
+                2,
+                BigDecimal.valueOf(20.0)
+        );
+
+        aOrder.addItem(aItemOne);
+        aOrder.addItem(aItemTwo);
+
+        aOrder.calculateTotalAmount(aOrderDelivery);
+
+        Assertions.assertEquals(aOrderCode, aOrder.getOrderCode());
+        Assertions.assertEquals(2, aOrder.getOrderItems().size());
+        Assertions.assertEquals(new BigDecimal("49.50"), aOrder.getTotalAmount());
+        Assertions.assertEquals(aCustomerId, aOrder.getCustomerId());
+        Assertions.assertEquals(aCouponCode, aOrder.getCouponCode().get());
+        Assertions.assertEquals(aCouponPercentage, aOrder.getCouponPercentage());
+        Assertions.assertEquals(OrderStatus.WAITING_PAYMENT, aOrder.getOrderStatus());
+        Assertions.assertEquals(aOrderDelivery.getId(), aOrder.getOrderDeliveryId());
+        Assertions.assertEquals(aOrderPayment.getId(), aOrder.getOrderPaymentId());
+        Assertions.assertEquals(0, aOrder.getVersion());
+        Assertions.assertNotNull(aOrder.getCreatedAt());
+        Assertions.assertNotNull(aOrder.getUpdatedAt());
+        Assertions.assertDoesNotThrow(() -> aOrderDelivery.validate(new ThrowsValidationHandler()));
+        Assertions.assertDoesNotThrow(() -> aOrderPayment.validate(new ThrowsValidationHandler()));
+        Assertions.assertDoesNotThrow(() -> aOrder.validate(new ThrowsValidationHandler()));
+    }
+
+    @Test
+    void givenAValidValues_whenCallWith_shouldInstantiateOrder() {
+        final var aOrderId = "aOrderId";
+        final var aVersion = 0L;
+        final var aOrderCode = OrderCode.create(0);
+        final var aOrderStatus = OrderStatus.WAITING_PAYMENT;
+        final var aOrderItems = Set.of(
+                OrderItem.create(
+                        "aOrderId",
+                        "aProductId",
+                        "aSkuOne",
+                        1,
+                        BigDecimal.valueOf(10.0)
+                ),
+                OrderItem.create(
+                        "aOrderId",
+                        "aProductId",
+                        "aSkuTwo",
+                        2,
+                        BigDecimal.valueOf(20.0)
+                )
+        );
+        final var aTotalAmount = new BigDecimal("49.50");
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderDeliveryId = "aOrderDeliveryId";
+        final var aOrderPaymentId = "aOrderPaymentId";
+        final var aCreatedAt = InstantUtils.now();
+        final var aUpdatedAt = InstantUtils.now();
+
+        final var aOrder = Order.with(
+                aOrderId,
+                aVersion,
+                aOrderCode.getValue(),
+                aOrderStatus,
+                aOrderItems,
+                aTotalAmount,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDeliveryId,
+                aOrderPaymentId,
+                aCreatedAt,
+                aUpdatedAt
+        );
+
+        Assertions.assertEquals(aOrderId, aOrder.getId().getValue());
+        Assertions.assertEquals(aVersion, aOrder.getVersion());
+        Assertions.assertEquals(aOrderCode.getValue(), aOrder.getOrderCode().getValue());
+        Assertions.assertEquals(aOrderStatus, aOrder.getOrderStatus());
+        Assertions.assertEquals(aOrderItems, aOrder.getOrderItems());
+        Assertions.assertEquals(aTotalAmount, aOrder.getTotalAmount());
+        Assertions.assertEquals(aCustomerId, aOrder.getCustomerId());
+        Assertions.assertEquals(aCouponCode, aOrder.getCouponCode().get());
+        Assertions.assertEquals(aCouponPercentage, aOrder.getCouponPercentage());
+        Assertions.assertEquals(aOrderDeliveryId, aOrder.getOrderDeliveryId().getValue());
+        Assertions.assertEquals(aOrderPaymentId, aOrder.getOrderPaymentId().getValue());
+        Assertions.assertEquals(aCreatedAt, aOrder.getCreatedAt());
+        Assertions.assertEquals(aUpdatedAt, aOrder.getUpdatedAt());
+        Assertions.assertDoesNotThrow(() -> aOrder.validate(new ThrowsValidationHandler()));
+    }
+
+    @Test
+    void givenAValidValuesWithoutCoupon_whenCallNewOrder_shouldCreateNewOrder() {
+        final var aSequence = 0;
+        final var aCustomerId = "aCustomerId";
+        final var aOrderCode = OrderCode.create(aSequence);
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                null,
+                0,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+
+        final var aItemOne = OrderItem.create(
+                aOrder.getId().getValue(),
+                "aProductId",
+                "aSkuOne",
+                1,
+                BigDecimal.valueOf(10.0)
+        );
+        final var aItemTwo = OrderItem.create(
+                aOrder.getId().getValue(),
+                "aProductId",
+                "aSkuTwo",
+                2,
+                BigDecimal.valueOf(20.0)
+        );
+
+        aOrder.addItem(aItemOne);
+        aOrder.addItem(aItemTwo);
+
+        aOrder.calculateTotalAmount(aOrderDelivery);
+
+        Assertions.assertEquals(aOrderCode, aOrder.getOrderCode());
+        Assertions.assertEquals(2, aOrder.getOrderItems().size());
+        Assertions.assertEquals(new BigDecimal("55.00"), aOrder.getTotalAmount());
+        Assertions.assertEquals(aCustomerId, aOrder.getCustomerId());
+        Assertions.assertTrue(aOrder.getCouponCode().isEmpty());
+        Assertions.assertEquals(0, aOrder.getCouponPercentage());
+        Assertions.assertEquals(OrderStatus.WAITING_PAYMENT, aOrder.getOrderStatus());
+        Assertions.assertEquals(aOrderDelivery.getId(), aOrder.getOrderDeliveryId());
+        Assertions.assertEquals(aOrderPayment.getId(), aOrder.getOrderPaymentId());
+        Assertions.assertEquals(0, aOrder.getVersion());
+        Assertions.assertNotNull(aOrder.getCreatedAt());
+        Assertions.assertNotNull(aOrder.getUpdatedAt());
+        Assertions.assertDoesNotThrow(() -> aOrderDelivery.validate(new ThrowsValidationHandler()));
+        Assertions.assertDoesNotThrow(() -> aOrderPayment.validate(new ThrowsValidationHandler()));
+        Assertions.assertDoesNotThrow(() -> aOrder.validate(new ThrowsValidationHandler()));
+    }
+
+    @Test
+    void givenAValidValue_whenCallOrderStatusOf_shouldReturnOrderStatus() {
+        final var aOrderStatusName = "WAITING_PAYMENT";
+        final var aOrderStatus = OrderStatus.of(aOrderStatusName);
+
+        Assertions.assertEquals(OrderStatus.WAITING_PAYMENT, aOrderStatus.get());
+    }
+
+    @Test
+    void testOrderIdEqualsAndHashCode() {
+        final var aOrderId = OrderID.from("123456789");
+        final var anotherOrderId = OrderID.from("123456789");
+
+        Assertions.assertTrue(aOrderId.equals(anotherOrderId));
+        Assertions.assertTrue(aOrderId.equals(aOrderId));
+        Assertions.assertFalse(aOrderId.equals(null));
+        Assertions.assertFalse(aOrderId.equals(""));
+        Assertions.assertEquals(aOrderId.hashCode(), anotherOrderId.hashCode());
+    }
+
+    @Test
+    void givenAValidOrder_whenCallToString_shouldReturnString() {
+        final var aSequence = 0;
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+
+        final var aItemOne = OrderItem.create(
+                aOrder.getId().getValue(),
+                "aProductId",
+                "aSkuOne",
+                1,
+                BigDecimal.valueOf(10.0)
+        );
+        final var aItemTwo = OrderItem.create(
+                aOrder.getId().getValue(),
+                "aProductId",
+                "aSkuTwo",
+                2,
+                BigDecimal.valueOf(20.0)
+        );
+
+        aOrder.addItem(aItemOne);
+        aOrder.addItem(aItemTwo);
+
+        aOrder.calculateTotalAmount(aOrderDelivery);
+
+        final var aExpected = "Order(" +
+                "id=" + aOrder.getId().getValue() +
+                ", orderCode=" + aOrderCode.getValue() +
+                ", orderStatus=" + aOrder.getOrderStatus().name() +
+                ", orderItems=" + aOrder.getOrderItems().size() +
+                ", customerId='" + aCustomerId + '\'' +
+                ", couponCode='" + aCouponCode + '\'' +
+                ", couponPercentage=" + aCouponPercentage +
+                ", orderDeliveryId=" + aOrderDelivery.getId().getValue() +
+                ", orderPaymentId=" + aOrderPayment.getId().getValue() +
+                ", totalAmount=" + aOrder.getTotalAmount() +
+                ", createdAt=" + aOrder.getCreatedAt() +
+                ", updatedAt=" + aOrder.getUpdatedAt() +
+                ", version=" + aOrder.getVersion() +
+                ')';
+
+        Assertions.assertEquals(aExpected, aOrder.toString());
+    }
+
+    @Test
+    void givenAValidOrder_whenCallWith_shouldInstantiateOrder() {
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+
+        final var aOrderWith = Order.with(aOrder);
+
+        Assertions.assertEquals(aOrder.getId().getValue(), aOrderWith.getId().getValue());
+        Assertions.assertEquals(aOrder.getVersion(), aOrderWith.getVersion());
+        Assertions.assertEquals(aOrder.getOrderCode().getValue(), aOrderWith.getOrderCode().getValue());
+        Assertions.assertEquals(aOrder.getOrderStatus(), aOrderWith.getOrderStatus());
+        Assertions.assertEquals(aOrder.getOrderItems(), aOrderWith.getOrderItems());
+        Assertions.assertEquals(aOrder.getTotalAmount(), aOrderWith.getTotalAmount());
+        Assertions.assertEquals(aOrder.getCustomerId(), aOrderWith.getCustomerId());
+        Assertions.assertEquals(aOrder.getCouponCode().get(), aOrderWith.getCouponCode().get());
+        Assertions.assertEquals(aOrder.getCouponPercentage(), aOrderWith.getCouponPercentage());
+        Assertions.assertEquals(aOrder.getOrderDeliveryId().getValue(), aOrderWith.getOrderDeliveryId().getValue());
+        Assertions.assertEquals(aOrder.getOrderPaymentId().getValue(), aOrderWith.getOrderPaymentId().getValue());
+        Assertions.assertEquals(aOrder.getCreatedAt(), aOrderWith.getCreatedAt());
+        Assertions.assertEquals(aOrder.getUpdatedAt(), aOrderWith.getUpdatedAt());
+        Assertions.assertDoesNotThrow(() -> aOrderWith.validate(new ThrowsValidationHandler()));
+    }
+}

--- a/domain/src/test/java/com/kaua/ecommerce/domain/order/validations/OrderDeliveryValidationTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/order/validations/OrderDeliveryValidationTest.java
@@ -1,0 +1,623 @@
+package com.kaua.ecommerce.domain.order.validations;
+
+import com.kaua.ecommerce.domain.TestValidationHandler;
+import com.kaua.ecommerce.domain.UnitTest;
+import com.kaua.ecommerce.domain.order.OrderDelivery;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OrderDeliveryValidationTest extends UnitTest {
+
+    @Test
+    void givenInvalidNullFreightType_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = null;
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("freightType");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankFreightType_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("freightType");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidZeroFreightPrice_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 0.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.greaterThan("freightPrice", 0);
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidZeroDeliveryEstimated_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 0;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.greaterThan("deliveryEstimated", 0);
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullStreet_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final String aStreet = null;
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("street");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankStreet_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final String aStreet = "";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("street");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullNumber_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final String aNumber = null;
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("number");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankNumber_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        String aNumber = "";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("number");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankComplement_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final String aComplement = "";
+        final var aCity = "São Paulo";
+        final var aDistrict = "Centro";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.blankMessage("complement");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullCity_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final String aCity = null;
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("city");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankCity_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final String aCity = "";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("city");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullState_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final String aState = null;
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("state");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankState_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final String aState = "";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("state");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullZipCode_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final String aZipCode = null;
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("zipCode");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankZipCode_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final var aDistrict = "Centro";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final String aZipCode = "";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("zipCode");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullDistrict_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        final String aDistrict = null;
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("district");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankDistrict_whenCallNewOrderDelivery_shouldReturnDomainException() {
+        final String aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimated = 10;
+        final var aStreet = "Rua dos Bobos";
+        final var aNumber = "1";
+        final var aComplement = "Apto 101";
+        String aDistrict = "";
+        final var aCity = "São Paulo";
+        final var aState = "SP";
+        final var aZipCode = "12345-678";
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("district");
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimated,
+                aStreet,
+                aNumber,
+                aComplement,
+                aDistrict,
+                aCity,
+                aState,
+                aZipCode
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderDelivery.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+}

--- a/domain/src/test/java/com/kaua/ecommerce/domain/order/validations/OrderPaymentValidationTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/order/validations/OrderPaymentValidationTest.java
@@ -1,0 +1,71 @@
+package com.kaua.ecommerce.domain.order.validations;
+
+import com.kaua.ecommerce.domain.TestValidationHandler;
+import com.kaua.ecommerce.domain.UnitTest;
+import com.kaua.ecommerce.domain.order.OrderPayment;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OrderPaymentValidationTest extends UnitTest {
+
+    @Test
+    void givenInvalidNullPaymentMethodId_whenCallNewOrderPayment_shouldReturnDomainException() {
+        final String aPaymentMethodId = null;
+        final var aInstallments = 1;
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("paymentMethodId");
+
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                aPaymentMethodId,
+                aInstallments
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderPayment.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankPaymentMethodId_whenCallNewOrderPayment_shouldReturnDomainException() {
+        final String aPaymentMethodId = "";
+        final var aInstallments = 1;
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("paymentMethodId");
+
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                aPaymentMethodId,
+                aInstallments
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderPayment.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNegativeInstallments_whenCallNewOrderPayment_shouldReturnDomainException() {
+        final String aPaymentMethodId = "creditCard";
+        final var aInstallments = -1;
+
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = CommonErrorMessage.greaterThan("installments", -1);
+
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                aPaymentMethodId,
+                aInstallments
+        );
+
+        final var aValidationHandler = new TestValidationHandler();
+        aOrderPayment.validate(aValidationHandler);
+
+        Assertions.assertEquals(expectedErrorsCount, aValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aValidationHandler.getErrors().get(0).message());
+    }
+}

--- a/domain/src/test/java/com/kaua/ecommerce/domain/order/validations/OrderValidationTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/order/validations/OrderValidationTest.java
@@ -1,0 +1,485 @@
+package com.kaua.ecommerce.domain.order.validations;
+
+import com.kaua.ecommerce.domain.TestValidationHandler;
+import com.kaua.ecommerce.domain.UnitTest;
+import com.kaua.ecommerce.domain.exceptions.DomainException;
+import com.kaua.ecommerce.domain.exceptions.NotAcceptDuplicatedItemsException;
+import com.kaua.ecommerce.domain.order.*;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+public class OrderValidationTest extends UnitTest {
+
+    @Test
+    void givenAInvalidDuplicatedSku_whenCallNewOrder_shouldThrowsNotAcceptDuplicatedItemsException() {
+        final var aSequence = 0;
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+
+        final var expectedErrorMessage = "The item with SKU aSkuOne is already in the order";
+
+        final var aItemOne = OrderItem.create(
+                "aOrderId",
+                "aProductId",
+                "aSkuOne",
+                1,
+                BigDecimal.valueOf(10.0)
+        );
+
+        final var aItemTwo = OrderItem.create(
+                "aOrderId",
+                "aProductId",
+                "aSkuOne",
+                2,
+                BigDecimal.valueOf(20.0)
+        );
+
+        final var aItems = Set.of(aItemOne, aItemTwo);
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+        final var aOrderPaymentId = aOrderPayment.getId();
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPaymentId
+        );
+
+        final var aOutput = Assertions.assertThrows(NotAcceptDuplicatedItemsException.class,
+                () -> aItems.forEach(aOrder::addItem));
+
+        Assertions.assertEquals(expectedErrorMessage, aOutput.getMessage());
+    }
+
+    @Test
+    void givenInvalidBlankCustomerId_whenCallNewOrder_shouldReturnDomainException() {
+        final var aSequence = 0;
+        final var aCustomerId = " ";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+        final var aItem = OrderItem.create(
+                "aOrderId",
+                "aProductId",
+                "aSkuOne",
+                1,
+                BigDecimal.valueOf(10.0)
+        );
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("customerId");
+        final var expectedErrorCount = 1;
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+        aOrder.addItem(aItem);
+        aOrder.calculateTotalAmount(aOrderDelivery);
+
+        final var aTestValidationHandler = new TestValidationHandler();
+        aOrder.validate(aTestValidationHandler);
+
+        Assertions.assertEquals(expectedErrorCount, aTestValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aTestValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullCustomerId_whenCallNewOrder_shouldReturnDomainException() {
+        final var aSequence = 0;
+        final String aCustomerId = null;
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+        final var aItem = OrderItem.create(
+                "aOrderId",
+                "aProductId",
+                "aSkuOne",
+                1,
+                BigDecimal.valueOf(10.0)
+        );
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("customerId");
+        final var expectedErrorCount = 1;
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+        aOrder.addItem(aItem);
+        aOrder.calculateTotalAmount(aOrderDelivery);
+
+        final var aTestValidationHandler = new TestValidationHandler();
+        aOrder.validate(aTestValidationHandler);
+
+        Assertions.assertEquals(expectedErrorCount, aTestValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aTestValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankCouponCode_whenCallNewOrder_shouldReturnDomainException() {
+        final var aSequence = 0;
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = " ";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+        final var aItem = OrderItem.create(
+                "aOrderId",
+                "aProductId",
+                "aSkuOne",
+                1,
+                BigDecimal.valueOf(10.0)
+        );
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+
+        final var expectedErrorMessage = CommonErrorMessage.blankMessage("couponCode");
+        final var expectedErrorCount = 1;
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+        aOrder.addItem(aItem);
+        aOrder.calculateTotalAmount(aOrderDelivery);
+
+        final var aTestValidationHandler = new TestValidationHandler();
+        aOrder.validate(aTestValidationHandler);
+
+        Assertions.assertEquals(expectedErrorCount, aTestValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aTestValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNegativeCouponPercentage_whenCallNewOrder_shouldReturnDomainException() {
+        final var aSequence = 0;
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = -1.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+        final var aItem = OrderItem.create(
+                "aOrderId",
+                "aProductId",
+                "aSkuOne",
+                1,
+                BigDecimal.valueOf(10.0)
+        );
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+
+        final var expectedErrorMessage = CommonErrorMessage.greaterThan("couponPercentage", -1);
+        final var expectedErrorCount = 1;
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+        aOrder.addItem(aItem);
+        aOrder.calculateTotalAmount(aOrderDelivery);
+
+        final var aTestValidationHandler = new TestValidationHandler();
+        aOrder.validate(aTestValidationHandler);
+
+        Assertions.assertEquals(expectedErrorCount, aTestValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aTestValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullOrderDeliveryId_whenCallNewOrder_shouldReturnDomainException() {
+        final var aSequence = 0;
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+
+        final var expectedErrorMessage = CommonErrorMessage.nullMessage("orderDeliveryId");
+        final var expectedErrorCount = 1;
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> Order.newOrder(
+                        aOrderCode,
+                        aCustomerId,
+                        aCouponCode,
+                        aCouponPercentage,
+                        null,
+                        aOrderPayment.getId()
+                ));
+
+        Assertions.assertEquals(expectedErrorCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullOrderPaymentId_whenCallNewOrder_shouldReturnDomainException() {
+        final var aSequence = 0;
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+        final var aItem = OrderItem.create(
+                "aOrderId",
+                "aProductId",
+                "aSkuOne",
+                1,
+                BigDecimal.valueOf(10.0)
+        );
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+
+        final var expectedErrorMessage = CommonErrorMessage.nullMessage("orderPaymentId");
+        final var expectedErrorCount = 1;
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                null
+        );
+        aOrder.addItem(aItem);
+        aOrder.calculateTotalAmount(aOrderDelivery);
+
+        final var aTestValidationHandler = new TestValidationHandler();
+        aOrder.validate(aTestValidationHandler);
+
+        Assertions.assertEquals(expectedErrorCount, aTestValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aTestValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidNullOrderCode_whenCallOrderCodeWith_shouldThrowDomainException() {
+        final String aOrderCode = null;
+
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("orderCode");
+        final var expectedErrorCount = 1;
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderCode.with(aOrderCode));
+
+        Assertions.assertEquals(expectedErrorCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidBlankOrderCode_whenCallOrderCodeWith_shouldThrowDomainException() {
+        final String aOrderCode = " ";
+
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("orderCode");
+        final var expectedErrorCount = 1;
+
+        final var aException = Assertions.assertThrows(DomainException.class,
+                () -> OrderCode.with(aOrderCode));
+
+        Assertions.assertEquals(expectedErrorCount, aException.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aException.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenInvalidZeroOrderItem_whenCallValidate_shouldReturnDomainException() {
+        final var aSequence = 0;
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+
+        final var expectedErrorMessage = CommonErrorMessage.minSize("orderItems", 1);
+        final var expectedErrorCount = 2;
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+
+        final var aTestValidationHandler = new TestValidationHandler();
+        aOrder.validate(aTestValidationHandler);
+
+        Assertions.assertEquals(expectedErrorCount, aTestValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aTestValidationHandler.getErrors().get(0).message());
+    }
+
+    @Test
+    void givenValidOrderWithItemsButNotCallCalculate_whenCallValidate_shouldReturnDomainException() {
+        final var aSequence = 0;
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+        final var aOrderCode = OrderCode.create(aSequence);
+        final var aItem = OrderItem.create(
+                "aOrderId",
+                "aProductId",
+                "aSkuOne",
+                1,
+                BigDecimal.valueOf(10.0)
+        );
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "sedex",
+                5.0F,
+                5,
+                "aStreet",
+                "235",
+                null,
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                "aPaymentMethodId",
+                0
+        );
+
+        final var expectedErrorMessage = CommonErrorMessage.greaterThan("totalAmount", 0);
+        final var expectedErrorCount = 1;
+
+        final var aOrder = Order.newOrder(
+                aOrderCode,
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+        aOrder.addItem(aItem);
+
+        final var aTestValidationHandler = new TestValidationHandler();
+        aOrder.validate(aTestValidationHandler);
+
+        Assertions.assertEquals(expectedErrorCount, aTestValidationHandler.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aTestValidationHandler.getErrors().get(0).message());
+    }
+}

--- a/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductImageResourceTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/product/ProductImageResourceTest.java
@@ -1,6 +1,6 @@
 package com.kaua.ecommerce.domain.product;
 
-import com.kaua.ecommerce.domain.utils.Resource;
+import com.kaua.ecommerce.domain.resource.Resource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/domain/src/test/java/com/kaua/ecommerce/domain/resource/ResourceTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/resource/ResourceTest.java
@@ -1,5 +1,7 @@
-package com.kaua.ecommerce.domain.utils;
+package com.kaua.ecommerce.domain.resource;
 
+import com.kaua.ecommerce.domain.resource.Resource;
+import com.kaua.ecommerce.domain.utils.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/domain/src/test/java/com/kaua/ecommerce/domain/utils/SlugUtilsTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/utils/SlugUtilsTest.java
@@ -1,6 +1,7 @@
 package com.kaua.ecommerce.domain.utils;
 
 import com.kaua.ecommerce.domain.UnitTest;
+import com.kaua.ecommerce.domain.category.SlugUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/domain/src/test/java/com/kaua/ecommerce/domain/utils/SlugUtilsTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/utils/SlugUtilsTest.java
@@ -1,7 +1,6 @@
 package com.kaua.ecommerce.domain.utils;
 
 import com.kaua.ecommerce.domain.UnitTest;
-import com.kaua.ecommerce.domain.category.SlugUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/api/OrderAPI.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/api/OrderAPI.java
@@ -1,0 +1,29 @@
+package com.kaua.ecommerce.infrastructure.api;
+
+import com.kaua.ecommerce.infrastructure.order.models.CreateOrderInput;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Order")
+@RequestMapping(value = "v1/orders")
+public interface OrderAPI {
+
+    @PostMapping(
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @Operation(summary = "Create a new order")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Created successfully"),
+            @ApiResponse(responseCode = "422", description = "A validation error was thrown"),
+            @ApiResponse(responseCode = "500", description = "An internal server error was thrown")
+    })
+    ResponseEntity<?> createOrder(@RequestBody CreateOrderInput body);
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/api/controllers/OrderController.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/api/controllers/OrderController.java
@@ -1,0 +1,42 @@
+package com.kaua.ecommerce.infrastructure.api.controllers;
+
+import com.kaua.ecommerce.application.usecases.order.create.CreateOrderUseCase;
+import com.kaua.ecommerce.domain.order.Order;
+import com.kaua.ecommerce.infrastructure.api.OrderAPI;
+import com.kaua.ecommerce.infrastructure.order.models.CreateOrderInput;
+import com.kaua.ecommerce.infrastructure.utils.LogControllerResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OrderController implements OrderAPI {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderController.class);
+
+    private final CreateOrderUseCase createOrderUseCase;
+
+    public OrderController(final CreateOrderUseCase createOrderUseCase) {
+        this.createOrderUseCase = createOrderUseCase;
+    }
+
+    @Override
+    public ResponseEntity<?> createOrder(CreateOrderInput body) {
+        final var aCommand = body.toCommand();
+
+        final var aResult = this.createOrderUseCase.execute(aCommand);
+
+        LogControllerResult.logResult(
+                log,
+                Order.class,
+                "createOrder",
+                aResult
+        );
+
+        return aResult.isLeft()
+                ? ResponseEntity.unprocessableEntity().body(aResult.getLeft())
+                : ResponseEntity.status(HttpStatus.CREATED).body(aResult.getRight());
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/FreightUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/FreightUseCaseConfig.java
@@ -1,6 +1,8 @@
 package com.kaua.ecommerce.infrastructure.configurations.usecases;
 
 import com.kaua.ecommerce.application.gateways.FreightGateway;
+import com.kaua.ecommerce.application.usecases.freight.calculate.CalculateFreightUseCase;
+import com.kaua.ecommerce.application.usecases.freight.calculate.DefaultCalculateFreightUseCase;
 import com.kaua.ecommerce.application.usecases.freight.list.DefaultListFreightsByCepUseCase;
 import com.kaua.ecommerce.application.usecases.freight.list.ListFreightsByCepUseCase;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +17,11 @@ public class FreightUseCaseConfig {
 
     public FreightUseCaseConfig(final FreightGateway freightGateway) {
         this.freightGateway = Objects.requireNonNull(freightGateway);
+    }
+
+    @Bean
+    public CalculateFreightUseCase calculateFreightUseCase() {
+        return new DefaultCalculateFreightUseCase(this.freightGateway);
     }
 
     @Bean

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/OrderUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/configurations/usecases/OrderUseCaseConfig.java
@@ -1,0 +1,57 @@
+package com.kaua.ecommerce.infrastructure.configurations.usecases;
+
+import com.kaua.ecommerce.application.adapters.TransactionManager;
+import com.kaua.ecommerce.application.gateways.order.*;
+import com.kaua.ecommerce.application.usecases.order.create.CreateOrderUseCase;
+import com.kaua.ecommerce.application.usecases.order.create.DefaultCreateOrderUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Objects;
+
+@Configuration
+public class OrderUseCaseConfig {
+
+    private final OrderGateway orderGateway;
+    private final OrderCouponGateway orderCouponGateway;
+    private final OrderCustomerGateway orderCustomerGateway;
+    private final OrderDeliveryGateway orderDeliveryGateway;
+    private final OrderPaymentGateway orderPaymentGateway;
+    private final OrderProductGateway orderProductGateway;
+    private final OrderFreightGateway orderFreightGateway;
+    private final TransactionManager transactionManager;
+
+    public OrderUseCaseConfig(
+            final OrderGateway orderGateway,
+            final OrderCouponGateway orderCouponGateway,
+            final OrderCustomerGateway orderCustomerGateway,
+            final OrderDeliveryGateway orderDeliveryGateway,
+            final OrderPaymentGateway orderPaymentGateway,
+            final OrderProductGateway orderProductGateway,
+            final OrderFreightGateway orderFreightGateway,
+            final TransactionManager transactionManager
+    ) {
+        this.orderGateway = Objects.requireNonNull(orderGateway);
+        this.orderCouponGateway = Objects.requireNonNull(orderCouponGateway);
+        this.orderCustomerGateway = Objects.requireNonNull(orderCustomerGateway);
+        this.orderDeliveryGateway = Objects.requireNonNull(orderDeliveryGateway);
+        this.orderPaymentGateway = Objects.requireNonNull(orderPaymentGateway);
+        this.orderProductGateway = Objects.requireNonNull(orderProductGateway);
+        this.orderFreightGateway = Objects.requireNonNull(orderFreightGateway);
+        this.transactionManager = Objects.requireNonNull(transactionManager);
+    }
+
+    @Bean
+    public CreateOrderUseCase createOrderUseCase() {
+        return new DefaultCreateOrderUseCase(
+                orderGateway,
+                orderCouponGateway,
+                orderCustomerGateway,
+                orderDeliveryGateway,
+                orderPaymentGateway,
+                orderProductGateway,
+                orderFreightGateway,
+                transactionManager
+        );
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/coupon/slot/CouponSlotMySQLGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/coupon/slot/CouponSlotMySQLGateway.java
@@ -52,7 +52,10 @@ public class CouponSlotMySQLGateway implements CouponSlotGateway {
     @Override
     public boolean deleteFirstSlotByCouponId(String couponId) {
         final var aResult = this.couponSlotJpaEntityRepository.deleteFirstSlotByCouponId(couponId);
-        log.info("deleted first coupon slot with coupon id: {}", couponId);
-        return aResult == 1;
+        if (aResult == 1) {
+            log.info("deleted first coupon slot with coupon id: {}", couponId);
+            return true;
+        }
+        return false;
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/freight/FreightGatewayImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/freight/FreightGatewayImpl.java
@@ -1,8 +1,8 @@
 package com.kaua.ecommerce.infrastructure.freight;
 
 import com.kaua.ecommerce.application.gateways.FreightGateway;
-import com.kaua.ecommerce.application.gateways.commands.CalculateFreightCommand;
-import com.kaua.ecommerce.application.gateways.commands.ListFreightsCommand;
+import com.kaua.ecommerce.application.gateways.commands.CalculateFreightInput;
+import com.kaua.ecommerce.application.gateways.commands.ListFreightsInput;
 import com.kaua.ecommerce.domain.freight.Freight;
 import com.kaua.ecommerce.domain.freight.FreightType;
 import org.springframework.stereotype.Component;
@@ -14,7 +14,7 @@ import java.util.List;
 public class FreightGatewayImpl implements FreightGateway {
 
     @Override
-    public Freight calculateFreight(CalculateFreightCommand aCommand) {
+    public Freight calculateFreight(CalculateFreightInput aCommand) {
         final var aFreightCalculator = FreightCalculatorFactory.create(aCommand.type());
         final var aFreightResponse = aFreightCalculator.calculate(
                 aCommand.cep(),
@@ -31,7 +31,7 @@ public class FreightGatewayImpl implements FreightGateway {
     }
 
     @Override
-    public List<Freight> listFreights(ListFreightsCommand aCommand) {
+    public List<Freight> listFreights(ListFreightsInput aCommand) {
         final List<Freight> aFreights = new ArrayList<>();
 
         for (final var aType : FreightType.values()) {

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderCouponGatewayImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderCouponGatewayImpl.java
@@ -1,0 +1,27 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.application.gateways.order.OrderCouponGateway;
+import com.kaua.ecommerce.application.usecases.coupon.slot.remove.RemoveCouponSlotUseCase;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class OrderCouponGatewayImpl implements OrderCouponGateway {
+
+    private final RemoveCouponSlotUseCase removeCouponSlotUseCase;
+
+    public OrderCouponGatewayImpl(final RemoveCouponSlotUseCase removeCouponSlotUseCase) {
+        this.removeCouponSlotUseCase = Objects.requireNonNull(removeCouponSlotUseCase);
+    }
+
+    @Override
+    public OrderCouponApplyOutput applyCoupon(String couponCode) {
+        final var aOutput = this.removeCouponSlotUseCase.execute(couponCode);
+        return new OrderCouponApplyOutput(
+                aOutput.couponId(),
+                aOutput.couponCode(),
+                aOutput.couponPercentage()
+        );
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderCustomerGatewayImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderCustomerGatewayImpl.java
@@ -1,0 +1,37 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.application.gateways.order.OrderCustomerGateway;
+import com.kaua.ecommerce.application.usecases.customer.retrieve.get.GetCustomerByAccountIdUseCase;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Component
+public class OrderCustomerGatewayImpl implements OrderCustomerGateway {
+
+    private final GetCustomerByAccountIdUseCase getCustomerByAccountIdUseCase;
+
+    public OrderCustomerGatewayImpl(final GetCustomerByAccountIdUseCase getCustomerByAccountIdUseCase) {
+        this.getCustomerByAccountIdUseCase = Objects.requireNonNull(getCustomerByAccountIdUseCase);
+    }
+
+    @Override
+    public Optional<OrderCustomerOutput> findByCustomerId(String customerId) {
+        try {
+            final var aCustomer = this.getCustomerByAccountIdUseCase.execute(customerId);
+            return Optional.of(new OrderCustomerOutput(
+                    aCustomer.accountId(),
+                    aCustomer.address().zipCode(),
+                    aCustomer.address().street(),
+                    aCustomer.address().number(),
+                    aCustomer.address().complement(),
+                    aCustomer.address().district(),
+                    aCustomer.address().city(),
+                    aCustomer.address().state()
+            ));
+        } catch (final Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderDeliveryMySQLGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderDeliveryMySQLGateway.java
@@ -1,0 +1,26 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.application.gateways.order.OrderDeliveryGateway;
+import com.kaua.ecommerce.domain.order.OrderDelivery;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntity;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntityRepository;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderPaymentJpaEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class OrderDeliveryMySQLGateway implements OrderDeliveryGateway {
+
+    private final OrderDeliveryJpaEntityRepository orderDeliveryJpaEntityRepository;
+
+    public OrderDeliveryMySQLGateway(final OrderDeliveryJpaEntityRepository orderDeliveryJpaEntityRepository) {
+        this.orderDeliveryJpaEntityRepository = Objects.requireNonNull(orderDeliveryJpaEntityRepository);
+    }
+
+    @Override
+    public OrderDelivery create(OrderDelivery orderDelivery) {
+        this.orderDeliveryJpaEntityRepository.save(OrderDeliveryJpaEntity.toEntity(orderDelivery));
+        return orderDelivery;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderFreightGatewayImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderFreightGatewayImpl.java
@@ -1,0 +1,39 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.application.gateways.order.OrderFreightGateway;
+import com.kaua.ecommerce.application.usecases.freight.calculate.CalculateFreightCommand;
+import com.kaua.ecommerce.application.usecases.freight.calculate.CalculateFreightItemsCommand;
+import com.kaua.ecommerce.application.usecases.freight.calculate.CalculateFreightUseCase;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Component
+public class OrderFreightGatewayImpl implements OrderFreightGateway {
+
+    private final CalculateFreightUseCase calculateFreightUseCase;
+
+    public OrderFreightGatewayImpl(final CalculateFreightUseCase calculateFreightUseCase) {
+        this.calculateFreightUseCase = Objects.requireNonNull(calculateFreightUseCase);
+    }
+
+    @Override
+    public OrderFreightDetails calculateFreight(CalculateOrderFreightInput input) {
+        final var aFreight = this.calculateFreightUseCase.execute(CalculateFreightCommand.with(
+                input.zipCode(),
+                input.type(),
+                input.items().stream().map(item -> CalculateFreightItemsCommand.with(
+                        item.height(),
+                        item.width(),
+                        item.length(),
+                        item.weight()
+                )).collect(Collectors.toSet()))
+        );
+        return new OrderFreightDetails(
+                aFreight.getType().name(),
+                aFreight.getPrice(),
+                aFreight.getDeadline()
+        );
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderMySQLGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderMySQLGateway.java
@@ -1,0 +1,56 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.application.gateways.order.OrderGateway;
+import com.kaua.ecommerce.domain.order.Order;
+import com.kaua.ecommerce.domain.order.OrderItem;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderItemJpaEntity;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderItemJpaEntityRepository;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntity;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntityRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+import java.util.Set;
+
+@Component
+public class OrderMySQLGateway implements OrderGateway {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderMySQLGateway.class);
+
+    private final OrderJpaEntityRepository orderJpaEntityRepository;
+    private final OrderItemJpaEntityRepository orderItemJpaEntityRepository;
+
+    public OrderMySQLGateway(
+            final OrderJpaEntityRepository orderJpaEntityRepository,
+            final OrderItemJpaEntityRepository orderItemJpaEntityRepository
+    ) {
+        this.orderJpaEntityRepository = Objects.requireNonNull(orderJpaEntityRepository);
+        this.orderItemJpaEntityRepository = Objects.requireNonNull(orderItemJpaEntityRepository);
+    }
+
+    @Override
+    public Order create(final Order order) {
+        this.orderJpaEntityRepository.save(OrderJpaEntity.toEntity(order));
+        log.info("inserted order: {}", order);
+        return order;
+    }
+
+    @Override
+    public long count() {
+        return this.orderJpaEntityRepository.getNextSequence();
+    }
+
+    @Override
+    public Set<OrderItem> createInBatch(Set<OrderItem> orderItems) {
+        final var aOrderItemsEntity = orderItems.stream()
+                .map(OrderItemJpaEntity::toEntity)
+                .toList();
+
+        final var aResult = this.orderItemJpaEntityRepository.saveAll(aOrderItemsEntity);
+
+        log.info("inserted order items: {}", aResult.size());
+        return orderItems;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderPaymentMySQLGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderPaymentMySQLGateway.java
@@ -1,0 +1,25 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.application.gateways.order.OrderPaymentGateway;
+import com.kaua.ecommerce.domain.order.OrderPayment;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderPaymentJpaEntity;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderPaymentJpaEntityRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class OrderPaymentMySQLGateway implements OrderPaymentGateway {
+
+    private final OrderPaymentJpaEntityRepository orderPaymentJpaEntityRepository;
+
+    public OrderPaymentMySQLGateway(final OrderPaymentJpaEntityRepository orderPaymentJpaEntityRepository) {
+        this.orderPaymentJpaEntityRepository = Objects.requireNonNull(orderPaymentJpaEntityRepository);
+    }
+
+    @Override
+    public OrderPayment create(OrderPayment orderPayment) {
+        this.orderPaymentJpaEntityRepository.save(OrderPaymentJpaEntity.toEntity(orderPayment));
+        return orderPayment;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderProductGatewayImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderProductGatewayImpl.java
@@ -1,0 +1,17 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.application.gateways.order.OrderProductGateway;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class OrderProductGatewayImpl implements OrderProductGateway {
+
+    // TODO: Implement the method getProductDetailsBySku
+
+    @Override
+    public Optional<OrderProductDetails> getProductDetailsBySku(String sku) {
+        return Optional.empty();
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/models/CreateOrderInput.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/models/CreateOrderInput.java
@@ -1,0 +1,28 @@
+package com.kaua.ecommerce.infrastructure.order.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kaua.ecommerce.application.usecases.order.create.CreateOrderCommand;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record CreateOrderInput(
+        @JsonProperty("customer_id") String customerId,
+        @JsonProperty("coupon_code") String couponCode,
+        @JsonProperty("freight_type") String freightType,
+        @JsonProperty("payment_method_id") String paymentMethodId,
+        @JsonProperty("installments") int installments,
+        @JsonProperty("items") List<CreateOrderItemInput> items
+) {
+
+    public CreateOrderCommand toCommand() {
+        return CreateOrderCommand.with(
+                customerId,
+                couponCode,
+                freightType,
+                paymentMethodId,
+                installments,
+                items.stream().map(CreateOrderItemInput::toCommand).collect(Collectors.toSet())
+        );
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/models/CreateOrderItemInput.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/models/CreateOrderItemInput.java
@@ -1,0 +1,15 @@
+package com.kaua.ecommerce.infrastructure.order.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kaua.ecommerce.application.usecases.order.create.CreateOrderItemsCommand;
+
+public record CreateOrderItemInput(
+        @JsonProperty("product_id") String productId,
+        @JsonProperty("sku") String sku,
+        @JsonProperty("quantity") int quantity
+) {
+
+    public CreateOrderItemsCommand toCommand() {
+        return CreateOrderItemsCommand.with(productId, sku, quantity);
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderDeliveryJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderDeliveryJpaEntity.java
@@ -1,0 +1,195 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import com.kaua.ecommerce.domain.order.OrderDelivery;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.Optional;
+
+@Table(name = "orders_deliveries")
+@Entity
+public class OrderDeliveryJpaEntity {
+
+    @Id
+    private String id;
+
+    @Column(name = "freight_type", nullable = false)
+    private String freightType;
+
+    @Column(name = "freight_price", nullable = false)
+    private float freightPrice;
+
+    @Column(name = "delivery_estimated", nullable = false)
+    private int deliveryEstimated;
+
+    @Column(name = "street", nullable = false)
+    private String street;
+
+    @Column(name = "number", nullable = false)
+    private String number;
+
+    @Column(name = "complement")
+    private String complement;
+
+    @Column(name = "district", nullable = false)
+    private String district;
+
+    @Column(name = "city", nullable = false)
+    private String city;
+
+    @Column(name = "state", nullable = false)
+    private String state;
+
+    @Column(name = "zip_code", nullable = false)
+    private String zipCode;
+
+    public OrderDeliveryJpaEntity() {}
+
+    private OrderDeliveryJpaEntity(
+            final String id,
+            final String freightType,
+            final float freightPrice,
+            final int deliveryEstimated,
+            final String street,
+            final String number,
+            final String complement,
+            final String district,
+            final String city,
+            final String state,
+            final String zipCode
+    ) {
+        this.id = id;
+        this.freightType = freightType;
+        this.freightPrice = freightPrice;
+        this.deliveryEstimated = deliveryEstimated;
+        this.street = street;
+        this.number = number;
+        this.complement = complement;
+        this.district = district;
+        this.city = city;
+        this.state = state;
+        this.zipCode = zipCode;
+    }
+
+    public static OrderDeliveryJpaEntity toEntity(final OrderDelivery aOrderDelivery) {
+        return new OrderDeliveryJpaEntity(
+                aOrderDelivery.getId().getValue(),
+                aOrderDelivery.getFreightType(),
+                aOrderDelivery.getFreightPrice(),
+                aOrderDelivery.getDeliveryEstimated(),
+                aOrderDelivery.getStreet(),
+                aOrderDelivery.getNumber(),
+                aOrderDelivery.getComplement().orElse(null),
+                aOrderDelivery.getDistrict(),
+                aOrderDelivery.getCity(),
+                aOrderDelivery.getState(),
+                aOrderDelivery.getZipCode()
+        );
+    }
+
+    public OrderDelivery toDomain() {
+        return OrderDelivery.with(
+                getId(),
+                getFreightType(),
+                getFreightPrice(),
+                getDeliveryEstimated(),
+                getStreet(),
+                getNumber(),
+                getComplement().orElse(null),
+                getDistrict(),
+                getCity(),
+                getState(),
+                getZipCode()
+        );
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getFreightType() {
+        return freightType;
+    }
+
+    public void setFreightType(String freightType) {
+        this.freightType = freightType;
+    }
+
+    public float getFreightPrice() {
+        return freightPrice;
+    }
+
+    public void setFreightPrice(float freightPrice) {
+        this.freightPrice = freightPrice;
+    }
+
+    public int getDeliveryEstimated() {
+        return deliveryEstimated;
+    }
+
+    public void setDeliveryEstimated(int deliveryEstimated) {
+        this.deliveryEstimated = deliveryEstimated;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    public Optional<String> getComplement() {
+        return Optional.ofNullable(complement);
+    }
+
+    public void setComplement(String complement) {
+        this.complement = complement;
+    }
+
+    public String getDistrict() {
+        return district;
+    }
+
+    public void setDistrict(String district) {
+        this.district = district;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getZipCode() {
+        return zipCode;
+    }
+
+    public void setZipCode(String zipCode) {
+        this.zipCode = zipCode;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderDeliveryJpaEntityRepository.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderDeliveryJpaEntityRepository.java
@@ -1,0 +1,6 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderDeliveryJpaEntityRepository extends JpaRepository<OrderDeliveryJpaEntity, String> {
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderItemJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderItemJpaEntity.java
@@ -1,0 +1,121 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import com.kaua.ecommerce.domain.order.OrderItem;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+
+@Table(name = "orders_items")
+@Entity
+public class OrderItemJpaEntity {
+
+    @Id
+    private String id;
+
+    @Column(name = "order_id", nullable = false)
+    private String orderId;
+
+    @Column(name = "product_id", nullable = false)
+    private String productId;
+
+    @Column(name = "sku", nullable = false)
+    private String sku;
+
+    @Column(name = "quantity", nullable = false)
+    private int quantity;
+
+    @Column(name = "price", nullable = false)
+    private BigDecimal price;
+
+    public OrderItemJpaEntity() {
+    }
+
+    private OrderItemJpaEntity(
+            final String id,
+            final String orderId,
+            final String productId,
+            final String sku,
+            final int quantity,
+            final BigDecimal price
+    ) {
+        this.id = id;
+        this.orderId = orderId;
+        this.productId = productId;
+        this.sku = sku;
+        this.quantity = quantity;
+        this.price = price;
+    }
+
+    public static OrderItemJpaEntity toEntity(final OrderItem aOrderItem) {
+        return new OrderItemJpaEntity(
+                aOrderItem.getOrderItemId(),
+                aOrderItem.getOrderId(),
+                aOrderItem.getProductId(),
+                aOrderItem.getSku(),
+                aOrderItem.getQuantity(),
+                aOrderItem.getPrice()
+        );
+    }
+
+    public OrderItem toDomain() {
+        return OrderItem.with(
+                getId(),
+                getOrderId(),
+                getProductId(),
+                getSku(),
+                getQuantity(),
+                getPrice()
+        );
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(String orderId) {
+        this.orderId = orderId;
+    }
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public String getSku() {
+        return sku;
+    }
+
+    public void setSku(String sku) {
+        this.sku = sku;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public void setPrice(BigDecimal price) {
+        this.price = price;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderItemJpaEntityRepository.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderItemJpaEntityRepository.java
@@ -1,0 +1,6 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemJpaEntityRepository extends JpaRepository<OrderItemJpaEntity, String> {
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderJpaEntity.java
@@ -1,0 +1,232 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import com.kaua.ecommerce.domain.order.Order;
+import com.kaua.ecommerce.domain.order.OrderItem;
+import com.kaua.ecommerce.domain.order.OrderStatus;
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Table(name = "orders")
+@Entity
+public class OrderJpaEntity {
+
+    @Id
+    private String id;
+
+    @Column(name = "order_code", nullable = false)
+    private String orderCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private OrderStatus status;
+
+    @Column(name = "customer_id", nullable = false)
+    private String customerId;
+
+    @Column(name = "total_price", nullable = false)
+    private BigDecimal totalPrice;
+
+    @Column(name = "coupon_code")
+    private String couponCode;
+
+    @Column(name = "coupon_percentage")
+    private float couponPercentage;
+
+    @Column(name = "order_delivery_id", nullable = false)
+    private String orderDeliveryId;
+
+    @Column(name = "order_payment_id", nullable = false)
+    private String orderPaymentId;
+
+    @Column(name = "created_at", nullable = false, columnDefinition = "DATETIME(6)")
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false, columnDefinition = "DATETIME(6)")
+    private Instant updatedAt;
+
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "order_id")
+    private Set<OrderItemJpaEntity> orderItems;
+
+    @Version
+    private long version;
+
+    public OrderJpaEntity() {
+    }
+
+    private OrderJpaEntity(
+            final String id,
+            final String orderCode,
+            final OrderStatus status,
+            final String customerId,
+            final BigDecimal totalPrice,
+            final String couponCode,
+            final float couponPercentage,
+            final String orderDeliveryId,
+            final String orderPaymentId,
+            final Instant createdAt,
+            final Instant updatedAt,
+            final long version
+    ) {
+        this.id = id;
+        this.orderCode = orderCode;
+        this.status = status;
+        this.customerId = customerId;
+        this.totalPrice = totalPrice;
+        this.couponCode = couponCode;
+        this.couponPercentage = couponPercentage;
+        this.orderDeliveryId = orderDeliveryId;
+        this.orderPaymentId = orderPaymentId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.orderItems = new HashSet<>();
+        this.version = version;
+    }
+
+    public static OrderJpaEntity toEntity(final Order aOrder) {
+        final var aEntity =  new OrderJpaEntity(
+                aOrder.getId().getValue(),
+                aOrder.getOrderCode().getValue(),
+                aOrder.getOrderStatus(),
+                aOrder.getCustomerId(),
+                aOrder.getTotalAmount(),
+                aOrder.getCouponCode().orElse(null),
+                aOrder.getCouponPercentage(),
+                aOrder.getOrderDeliveryId().getValue(),
+                aOrder.getOrderPaymentId().getValue(),
+                aOrder.getCreatedAt(),
+                aOrder.getUpdatedAt(),
+                aOrder.getVersion()
+        );
+
+        aOrder.getOrderItems().forEach(aEntity::addOrderItem);
+        return aEntity;
+    }
+
+    public Order toDomain() {
+        return Order.with(
+                getId(),
+                getVersion(),
+                getOrderCode(),
+                getStatus(),
+                getOrderItems().stream().map(OrderItemJpaEntity::toDomain).collect(Collectors.toSet()),
+                getTotalPrice(),
+                getCustomerId(),
+                getCouponCode(),
+                getCouponPercentage(),
+                getOrderDeliveryId(),
+                getOrderPaymentId(),
+                getCreatedAt(),
+                getUpdatedAt()
+        );
+    }
+
+    public void addOrderItem(final OrderItem aOrderItem) {
+        this.orderItems.add(OrderItemJpaEntity.toEntity(aOrderItem));
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getOrderCode() {
+        return orderCode;
+    }
+
+    public void setOrderCode(String orderCode) {
+        this.orderCode = orderCode;
+    }
+
+    public OrderStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OrderStatus status) {
+        this.status = status;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(String customerId) {
+        this.customerId = customerId;
+    }
+
+    public BigDecimal getTotalPrice() {
+        return totalPrice;
+    }
+
+    public void setTotalPrice(BigDecimal totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+
+    public String getCouponCode() {
+        return couponCode;
+    }
+
+    public void setCouponCode(String couponCode) {
+        this.couponCode = couponCode;
+    }
+
+    public float getCouponPercentage() {
+        return couponPercentage;
+    }
+
+    public void setCouponPercentage(float couponPercentage) {
+        this.couponPercentage = couponPercentage;
+    }
+
+    public String getOrderDeliveryId() {
+        return orderDeliveryId;
+    }
+
+    public void setOrderDeliveryId(String orderDeliveryId) {
+        this.orderDeliveryId = orderDeliveryId;
+    }
+
+    public String getOrderPaymentId() {
+        return orderPaymentId;
+    }
+
+    public void setOrderPaymentId(String orderPaymentId) {
+        this.orderPaymentId = orderPaymentId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Set<OrderItemJpaEntity> getOrderItems() {
+        return orderItems;
+    }
+
+    public void setOrderItems(Set<OrderItemJpaEntity> orderItems) {
+        this.orderItems = orderItems;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderJpaEntityRepository.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderJpaEntityRepository.java
@@ -1,0 +1,10 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface OrderJpaEntityRepository extends JpaRepository<OrderJpaEntity, String> {
+
+    @Query(value = "SELECT NEXTVAL('order_code_sequence')", nativeQuery = true)
+    Long getNextSequence();
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderPaymentJpaEntity.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderPaymentJpaEntity.java
@@ -1,0 +1,74 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import com.kaua.ecommerce.domain.order.OrderPayment;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Table(name = "orders_payments")
+@Entity
+public class OrderPaymentJpaEntity {
+
+    @Id
+    private String id;
+
+    @Column(name = "payment_method_id", nullable = false)
+    private String paymentMethodId;
+
+    @Column(name = "installments", nullable = false)
+    private int installments;
+
+    public OrderPaymentJpaEntity() {
+    }
+
+    private OrderPaymentJpaEntity(
+            final String id,
+            final String paymentMethodId,
+            final int installments
+    ) {
+        this.id = id;
+        this.paymentMethodId = paymentMethodId;
+        this.installments = installments;
+    }
+
+    public static OrderPaymentJpaEntity toEntity(final OrderPayment aOrderPayment) {
+        return new OrderPaymentJpaEntity(
+                aOrderPayment.getId().getValue(),
+                aOrderPayment.getPaymentMethodId(),
+                aOrderPayment.getInstallments()
+        );
+    }
+
+    public OrderPayment toDomain() {
+        return OrderPayment.with(
+                getId(),
+                getPaymentMethodId(),
+                getInstallments()
+        );
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getPaymentMethodId() {
+        return paymentMethodId;
+    }
+
+    public void setPaymentMethodId(String paymentMethodId) {
+        this.paymentMethodId = paymentMethodId;
+    }
+
+    public int getInstallments() {
+        return installments;
+    }
+
+    public void setInstallments(int installments) {
+        this.installments = installments;
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderPaymentJpaEntityRepository.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderPaymentJpaEntityRepository.java
@@ -1,0 +1,6 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderPaymentJpaEntityRepository extends JpaRepository<OrderPaymentJpaEntity, String> {
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/StorageService.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/StorageService.java
@@ -1,6 +1,6 @@
 package com.kaua.ecommerce.infrastructure.service;
 
-import com.kaua.ecommerce.domain.utils.Resource;
+import com.kaua.ecommerce.domain.resource.Resource;
 
 import java.util.List;
 

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/impl/S3StorageServiceImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/impl/S3StorageServiceImpl.java
@@ -1,6 +1,6 @@
 package com.kaua.ecommerce.infrastructure.service.impl;
 
-import com.kaua.ecommerce.domain.utils.Resource;
+import com.kaua.ecommerce.domain.resource.Resource;
 import com.kaua.ecommerce.infrastructure.exceptions.FileStorageException;
 import com.kaua.ecommerce.infrastructure.service.StorageService;
 import software.amazon.awssdk.core.sync.RequestBody;

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/local/InMemoryStorageServiceImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/service/local/InMemoryStorageServiceImpl.java
@@ -1,6 +1,6 @@
 package com.kaua.ecommerce.infrastructure.service.local;
 
-import com.kaua.ecommerce.domain.utils.Resource;
+import com.kaua.ecommerce.domain.resource.Resource;
 import com.kaua.ecommerce.infrastructure.service.StorageService;
 
 import java.util.List;

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/utils/ResourceOf.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/utils/ResourceOf.java
@@ -1,7 +1,7 @@
 package com.kaua.ecommerce.infrastructure.utils;
 
 import com.kaua.ecommerce.domain.exceptions.DomainException;
-import com.kaua.ecommerce.domain.utils.Resource;
+import com.kaua.ecommerce.domain.resource.Resource;
 import com.kaua.ecommerce.domain.validation.Error;
 import com.kaua.ecommerce.infrastructure.exceptions.ImageSizeNotValidException;
 import com.kaua.ecommerce.infrastructure.exceptions.ImageTypeNotValidException;

--- a/infrastructure/src/main/resources/application-test-integration.yml
+++ b/infrastructure/src/main/resources/application-test-integration.yml
@@ -14,6 +14,12 @@ kafka:
     inventories:
       auto-create-topics: false
 
+#logging:
+#  level:
+#    org:
+#      apache:
+#        kafka: OFF
+
 spring:
   autoconfigure:
     exclude:

--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -91,6 +91,9 @@ spring:
       "[hibernate.dialect]": org.hibernate.dialect.MySQLDialect
       "[hibernate.generate_statistics]": false
       "[hibernate.connection.provider_disables_autocommit]": true
+      hibernate:
+        jdbc:
+          batch_size: 10
   rabbitmq:
     publisher-confirm-type: correlated
     publisher-returns: true

--- a/infrastructure/src/main/resources/db/migration/U18__CREATE_ORDERS_TABLES.sql
+++ b/infrastructure/src/main/resources/db/migration/U18__CREATE_ORDERS_TABLES.sql
@@ -1,0 +1,5 @@
+DROP TABLE orders_deliveries;
+DROP TABLE orders_payments;
+DROP TABLE orders_items;
+DROP TABLE orders;
+DROP SEQUENCE order_code_sequence;

--- a/infrastructure/src/main/resources/db/migration/V18__CREATE_ORDERS_TABLES.sql
+++ b/infrastructure/src/main/resources/db/migration/V18__CREATE_ORDERS_TABLES.sql
@@ -1,0 +1,47 @@
+CREATE TABLE orders_deliveries (
+    id VARCHAR(36) PRIMARY KEY NOT NULL,
+    freight_type VARCHAR(50) NOT NULL,
+    freight_price DECIMAL(19,2) NOT NULL,
+    delivery_estimated integer NOT NULL,
+    street VARCHAR(255) NOT NULL,
+    number VARCHAR(50) NOT NULL,
+    complement VARCHAR(255),
+    district VARCHAR(255) NOT NULL,
+    city VARCHAR(255) NOT NULL,
+    state VARCHAR(50) NOT NULL,
+    zip_code VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE orders_payments (
+    id VARCHAR(36) PRIMARY KEY NOT NULL,
+    payment_method_id VARCHAR(36) NOT NULL,
+    installments integer NOT NULL
+);
+
+CREATE TABLE orders (
+    id VARCHAR(36) PRIMARY KEY NOT NULL,
+    order_code VARCHAR(255) NOT NULL UNIQUE,
+    status VARCHAR(50) NOT NULL,
+    customer_id VARCHAR(36) NOT NULL,
+    total_price DECIMAL(19,2) NOT NULL,
+    coupon_code VARCHAR(255),
+    coupon_percentage DECIMAL(5,2),
+    order_delivery_id VARCHAR(36) NOT NULL,
+    order_payment_id VARCHAR(36) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    version BIGINT NOT NULL,
+    FOREIGN KEY (order_delivery_id) REFERENCES orders_deliveries(id) ON DELETE CASCADE,
+    FOREIGN KEY (order_payment_id) REFERENCES orders_payments(id) ON DELETE CASCADE
+);
+
+CREATE TABLE orders_items (
+    id VARCHAR(36) PRIMARY KEY NOT NULL,
+    order_id VARCHAR(36) NOT NULL,
+    product_id VARCHAR(36) NOT NULL,
+    sku VARCHAR(255) NOT NULL,
+    quantity integer NOT NULL,
+    price DECIMAL(19,2) NOT NULL
+);
+
+CREATE SEQUENCE order_code_sequence AS BIGINT START WITH 0 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;

--- a/infrastructure/src/test/java/com/kaua/ecommerce/application/order/create/CreateOrderUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/application/order/create/CreateOrderUseCaseIT.java
@@ -1,0 +1,164 @@
+package com.kaua.ecommerce.application.order.create;
+
+import com.kaua.ecommerce.application.gateways.order.OrderCustomerGateway;
+import com.kaua.ecommerce.application.gateways.order.OrderFreightGateway;
+import com.kaua.ecommerce.application.gateways.order.OrderProductGateway;
+import com.kaua.ecommerce.application.usecases.order.create.CreateOrderCommand;
+import com.kaua.ecommerce.application.usecases.order.create.CreateOrderItemsCommand;
+import com.kaua.ecommerce.application.usecases.order.create.CreateOrderUseCase;
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.infrastructure.IntegrationTest;
+import com.kaua.ecommerce.infrastructure.coupon.persistence.CouponJpaEntity;
+import com.kaua.ecommerce.infrastructure.coupon.persistence.CouponJpaEntityRepository;
+import com.kaua.ecommerce.infrastructure.coupon.slot.persistence.CouponSlotJpaEntity;
+import com.kaua.ecommerce.infrastructure.coupon.slot.persistence.CouponSlotJpaEntityRepository;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderItemJpaEntityRepository;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntityRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@IntegrationTest
+public class CreateOrderUseCaseIT {
+
+    @Autowired
+    private CreateOrderUseCase createOrderUseCase;
+
+    @Autowired
+    private OrderItemJpaEntityRepository orderItemJpaEntityRepository;
+
+    @Autowired
+    private OrderJpaEntityRepository orderJpaEntityRepository;
+
+    @Autowired
+    private CouponJpaEntityRepository couponJpaEntityRepository;
+
+    @Autowired
+    private CouponSlotJpaEntityRepository couponSlotJpaEntityRepository;
+
+    @MockBean
+    private OrderCustomerGateway orderCustomerGateway;
+
+    @MockBean
+    private OrderFreightGateway orderFreightGateway;
+
+    @MockBean
+    private OrderProductGateway orderProductGateway;
+
+    @Test
+    void testConcurrencyOnCallCreateOrderUseCase() {
+        final var aCustomer = Fixture.Customers.customerWithAllParams;
+
+        final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+        this.couponJpaEntityRepository.save(CouponJpaEntity.toEntity(aCoupon));
+
+        final var aCouponSlotOne = Fixture.Coupons.generateValidCouponSlot(aCoupon);
+
+        this.couponSlotJpaEntityRepository.saveAll(Set.of(
+                CouponSlotJpaEntity.toEntity(aCouponSlotOne)
+        ));
+
+        final var aCouponCode = aCoupon.getCode().getValue();
+        final var aCustomerId = aCustomer.getAccountId();
+        final var aFreightType = "PAC";
+        final var aPaymentMethodId = "payment-method-id";
+        final var aPaymentInstallments = 0;
+        final var aSkuCamiseta = Fixture.createSku("camiseta");
+        final var aOrderItems = Set.of(
+                CreateOrderItemsCommand.with(
+                        "product-id",
+                        aSkuCamiseta,
+                        10
+                ));
+
+        final var aExecutions = 5;
+        final var aCountSuccessExecutionAtomic = new AtomicInteger(0);
+        final var aCountErrorExecutionAtomic = new AtomicInteger(0);
+        final var aExpectedSuccessExecution = 1;
+        final var aExpectedErrorExecution = 4;
+
+        Mockito.when(this.orderCustomerGateway.findByCustomerId(Mockito.anyString()))
+                .thenReturn(Optional.of(new OrderCustomerGateway.OrderCustomerOutput(
+                        aCustomer.getAccountId(),
+                        aCustomer.getAddress().get().getZipCode(),
+                        aCustomer.getAddress().get().getStreet(),
+                        aCustomer.getAddress().get().getNumber(),
+                        aCustomer.getAddress().get().getComplement(),
+                        aCustomer.getAddress().get().getDistrict(),
+                        aCustomer.getAddress().get().getCity(),
+                        aCustomer.getAddress().get().getState()
+                ))).getMock();
+
+        Mockito.when(this.orderProductGateway.getProductDetailsBySku(Mockito.anyString()))
+                .thenReturn(Optional.of(new OrderProductGateway.OrderProductDetails(
+                        aSkuCamiseta,
+                        BigDecimal.valueOf(100.0),
+                        10.0,
+                        10.0,
+                        10.0,
+                        10.0
+                )));
+
+        Mockito.when(this.orderFreightGateway.calculateFreight(Mockito.any()))
+                .thenReturn(new OrderFreightGateway.OrderFreightDetails(
+                        aFreightType,
+                        10.0f,
+                        5
+                ));
+
+        Assertions.assertEquals(1, this.couponJpaEntityRepository.count());
+        Assertions.assertEquals(1, this.couponSlotJpaEntityRepository.count());
+
+        ExecutorService executorService = Executors.newFixedThreadPool(aExecutions);
+        List<Callable<Void>> tasks = new ArrayList<>();
+
+        for (int i = 0; i < aExecutions; i++) {
+            tasks.add(() -> {
+                try {
+                    this.createOrderUseCase.execute(
+                            CreateOrderCommand.with(
+                                    aCustomerId,
+                                    aCouponCode,
+                                    aFreightType,
+                                    aPaymentMethodId,
+                                    aPaymentInstallments,
+                                    aOrderItems
+                            )
+                    );
+                    aCountSuccessExecutionAtomic.incrementAndGet();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    aCountErrorExecutionAtomic.incrementAndGet();
+                }
+                return null;
+            });
+        }
+
+        try {
+            executorService.invokeAll(tasks);
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            executorService.shutdown();
+        }
+
+        Assertions.assertEquals(1, this.couponJpaEntityRepository.count());
+        Assertions.assertEquals(0, this.couponSlotJpaEntityRepository.count());
+        Assertions.assertEquals(1, this.orderJpaEntityRepository.count());
+        Assertions.assertEquals(1, this.orderItemJpaEntityRepository.count());
+        Assertions.assertEquals(aExpectedSuccessExecution, aCountSuccessExecutionAtomic.get());
+        Assertions.assertEquals(aExpectedErrorExecution, aCountErrorExecutionAtomic.get());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/config/JpaCleanUpExtension.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/config/JpaCleanUpExtension.java
@@ -7,6 +7,10 @@ import com.kaua.ecommerce.infrastructure.customer.address.persistence.AddressJpa
 import com.kaua.ecommerce.infrastructure.customer.persistence.CustomerJpaEntityRepository;
 import com.kaua.ecommerce.infrastructure.inventory.movement.persistence.InventoryMovementJpaEntityRepository;
 import com.kaua.ecommerce.infrastructure.inventory.persistence.InventoryJpaEntityRepository;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntityRepository;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderItemJpaEntityRepository;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntityRepository;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderPaymentJpaEntityRepository;
 import com.kaua.ecommerce.infrastructure.outbox.OutboxEventRepository;
 import com.kaua.ecommerce.infrastructure.product.persistence.ProductColorJpaEntityRepository;
 import com.kaua.ecommerce.infrastructure.product.persistence.ProductJpaEntityRepository;
@@ -34,7 +38,11 @@ public class JpaCleanUpExtension implements BeforeEachCallback {
                 appContext.getBean(InventoryJpaEntityRepository.class),
                 appContext.getBean(InventoryMovementJpaEntityRepository.class),
                 appContext.getBean(CouponSlotJpaEntityRepository.class),
-                appContext.getBean(CouponJpaEntityRepository.class)
+                appContext.getBean(CouponJpaEntityRepository.class),
+                appContext.getBean(OrderItemJpaEntityRepository.class),
+                appContext.getBean(OrderDeliveryJpaEntityRepository.class),
+                appContext.getBean(OrderPaymentJpaEntityRepository.class),
+                appContext.getBean(OrderJpaEntityRepository.class)
         ));
     }
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/api/OrderAPITest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/api/OrderAPITest.java
@@ -1,0 +1,133 @@
+package com.kaua.ecommerce.infrastructure.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kaua.ecommerce.application.either.Either;
+import com.kaua.ecommerce.application.usecases.order.create.CreateOrderCommand;
+import com.kaua.ecommerce.application.usecases.order.create.CreateOrderOutput;
+import com.kaua.ecommerce.application.usecases.order.create.CreateOrderUseCase;
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.domain.utils.CommonErrorMessage;
+import com.kaua.ecommerce.domain.validation.Error;
+import com.kaua.ecommerce.domain.validation.handler.NotificationHandler;
+import com.kaua.ecommerce.infrastructure.ControllerTest;
+import com.kaua.ecommerce.infrastructure.order.models.CreateOrderInput;
+import com.kaua.ecommerce.infrastructure.order.models.CreateOrderItemInput;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+@ControllerTest(controllers = OrderAPI.class)
+public class OrderAPITest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @MockBean
+    private CreateOrderUseCase createOrderUseCase;
+
+    @Test
+    void givenAValidInput_whenCallCreateOrder_thenReturnStatusOkAndOrderId() throws Exception {
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+
+        final var aCustomerId = "123";
+        final var aCouponCode = "COUPON";
+        final var aFreightType = "PAC";
+        final var aPaymentMethodId = "456";
+        final var aInstallments = 0;
+        final var aItems = List.of(
+                new CreateOrderItemInput("123", "sku-123", 1),
+                new CreateOrderItemInput("456", "sku-456", 2)
+        );
+
+        final var aInput = new CreateOrderInput(
+                aCustomerId,
+                aCouponCode,
+                aFreightType,
+                aPaymentMethodId,
+                aInstallments,
+                aItems
+        );
+
+        Mockito.when(createOrderUseCase.execute(Mockito.any()))
+                .thenReturn(Either.right(CreateOrderOutput.from(aOrder)));
+
+        final var request = MockMvcRequestBuilders.post("/v1/orders")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(this.mapper.writeValueAsString(aInput));
+
+        this.mvc.perform(request)
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.order_id", equalTo(aOrder.getId().getValue())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.order_code", equalTo(aOrder.getOrderCode().getValue())));
+
+        final var cmdCaptor = ArgumentCaptor.forClass(CreateOrderCommand.class);
+
+        Mockito.verify(createOrderUseCase, Mockito.times(1)).execute(cmdCaptor.capture());
+
+        final var actualCmd = cmdCaptor.getValue();
+
+        Assertions.assertEquals(aCustomerId, actualCmd.customerId());
+        Assertions.assertEquals(aCouponCode, actualCmd.couponCode());
+        Assertions.assertEquals(aFreightType, actualCmd.freightType());
+        Assertions.assertEquals(aPaymentMethodId, actualCmd.paymentMethodId());
+        Assertions.assertEquals(aInstallments, actualCmd.installments());
+        Assertions.assertEquals(aItems.size(), actualCmd.items().size());
+    }
+
+    @Test
+    void givenAnInvalidInputWithNullPaymentMethodId_whenCallCreateOrder_thenReturnStatusProcessableEntity() throws Exception {
+        final var aCustomerId = "123";
+        final var aCouponCode = "COUPON";
+        final var aFreightType = "PAC";
+        final String aPaymentMethodId = null;
+        final var aInstallments = 0;
+        final var aItems = List.of(
+                new CreateOrderItemInput("123", "sku-123", 1),
+                new CreateOrderItemInput("456", "sku-456", 2)
+        );
+
+        final var expectedErrorMessage = CommonErrorMessage.nullOrBlank("paymentMethodId");
+        final var expectedErrorCount = 1;
+
+        final var aInput = new CreateOrderInput(
+                aCustomerId,
+                aCouponCode,
+                aFreightType,
+                aPaymentMethodId,
+                aInstallments,
+                aItems
+        );
+
+        Mockito.when(createOrderUseCase.execute(Mockito.any()))
+                .thenReturn(Either.left(NotificationHandler.create(new Error(expectedErrorMessage))));
+
+        final var request = MockMvcRequestBuilders.post("/v1/orders")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(this.mapper.writeValueAsString(aInput));
+
+        this.mvc.perform(request)
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errors", hasSize(expectedErrorCount)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].message", equalTo(expectedErrorMessage)));
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/freight/FreightGatewayImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/freight/FreightGatewayImplTest.java
@@ -1,8 +1,8 @@
 package com.kaua.ecommerce.infrastructure.freight;
 
 import com.kaua.ecommerce.application.gateways.FreightGateway;
-import com.kaua.ecommerce.application.gateways.commands.CalculateFreightCommand;
-import com.kaua.ecommerce.application.gateways.commands.ListFreightsCommand;
+import com.kaua.ecommerce.application.gateways.commands.CalculateFreightInput;
+import com.kaua.ecommerce.application.gateways.commands.ListFreightsInput;
 import com.kaua.ecommerce.domain.freight.FreightType;
 import com.kaua.ecommerce.infrastructure.IntegrationTest;
 import org.junit.jupiter.api.Assertions;
@@ -17,7 +17,7 @@ public class FreightGatewayImplTest {
 
     @Test
     void givenAValidSedexFreightType_whenCalculateFreight_thenShouldReturnFreight() {
-        final var aCommand = CalculateFreightCommand.with(
+        final var aCommand = CalculateFreightInput.with(
                 "12345678",
                 FreightType.SEDEX,
                 110.0,
@@ -37,7 +37,7 @@ public class FreightGatewayImplTest {
 
     @Test
     void givenAValidPACFreightType_whenCalculateFreight_thenShouldReturnFreight() {
-        final var aCommand = CalculateFreightCommand.with(
+        final var aCommand = CalculateFreightInput.with(
                 "12345678",
                 FreightType.PAC,
                 10.0,
@@ -57,7 +57,7 @@ public class FreightGatewayImplTest {
 
     @Test
     void givenAValidCalculateFreightCommand_whenListFreights_thenShouldReturnFreights() {
-        final var aCommand = ListFreightsCommand.with(
+        final var aCommand = ListFreightsInput.with(
                 "12345678",
                 10.0,
                 10.0,
@@ -73,7 +73,7 @@ public class FreightGatewayImplTest {
 
     @Test
     void givenAnInvalidFreightType_whenCalculateFreight_thenShouldThrowException() {
-        final var aCommand = CalculateFreightCommand.with(
+        final var aCommand = CalculateFreightInput.with(
                 "12345678",
                 FreightType.UNKNOWN,
                 10.0,

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderCouponGatewayImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderCouponGatewayImplTest.java
@@ -1,0 +1,47 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.application.exceptions.CouponNoMoreAvailableException;
+import com.kaua.ecommerce.application.usecases.coupon.slot.remove.RemoveCouponSlotOutput;
+import com.kaua.ecommerce.application.usecases.coupon.slot.remove.RemoveCouponSlotUseCase;
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.infrastructure.IntegrationTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@IntegrationTest
+public class OrderCouponGatewayImplTest {
+
+    @Autowired
+    private OrderCouponGatewayImpl orderCouponGatewayImpl;
+
+    @MockBean
+    private RemoveCouponSlotUseCase removeCouponSlotUseCase;
+
+    @Test
+    void givenAValidCouponCode_whenCallApplyCoupon_thenCouponIsApplied() {
+        final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+
+        Mockito.when(removeCouponSlotUseCase.execute(aCoupon.getCode().getValue()))
+                .thenReturn(RemoveCouponSlotOutput.from(aCoupon));
+
+        final var aOutput = this.orderCouponGatewayImpl.applyCoupon(aCoupon.getCode().getValue());
+
+        Assertions.assertEquals(aCoupon.getId().getValue(), aOutput.couponId());
+        Assertions.assertEquals(aCoupon.getCode().getValue(), aOutput.couponCode());
+        Assertions.assertEquals(aCoupon.getPercentage(), aOutput.couponPercentage());
+    }
+
+    @Test
+    void givenAValidCouponCode_whenCallApplyCouponButNoMoreSlot_thenThrowCouponNoMoreAvailableException() {
+        final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+
+        Mockito.when(removeCouponSlotUseCase.execute(aCoupon.getCode().getValue()))
+                .thenThrow(new CouponNoMoreAvailableException());
+
+        Assertions.assertThrows(CouponNoMoreAvailableException.class, () ->
+                this.orderCouponGatewayImpl.applyCoupon(aCoupon.getCode().getValue()));
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderCustomerGatewayImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderCustomerGatewayImplTest.java
@@ -1,0 +1,56 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.application.usecases.customer.retrieve.get.GetCustomerByAccountIdOutput;
+import com.kaua.ecommerce.application.usecases.customer.retrieve.get.GetCustomerByAccountIdUseCase;
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.domain.customer.Customer;
+import com.kaua.ecommerce.domain.exceptions.NotFoundException;
+import com.kaua.ecommerce.infrastructure.IntegrationTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@IntegrationTest
+public class OrderCustomerGatewayImplTest {
+
+    @Autowired
+    private OrderCustomerGatewayImpl orderCustomerGatewayImpl;
+
+    @MockBean
+    private GetCustomerByAccountIdUseCase getCustomerByAccountIdUseCase;
+
+    @Test
+    void givenAValidAccountId_whenFindCustomerByAccountId_thenReturnCustomer() {
+        final var aCustomer = Fixture.Customers.customerWithAllParams;
+        final var aCustomerId = aCustomer.getAccountId();
+
+        Mockito.when(getCustomerByAccountIdUseCase.execute(aCustomerId))
+                .thenReturn(GetCustomerByAccountIdOutput.from(aCustomer));
+
+        final var aOutput = orderCustomerGatewayImpl.findByCustomerId(aCustomerId);
+
+        Assertions.assertTrue(aOutput.isPresent());
+        Assertions.assertEquals(aCustomer.getAccountId(), aOutput.get().customerId());
+        Assertions.assertEquals(aCustomer.getAddress().get().getZipCode(), aOutput.get().zipCode());
+        Assertions.assertEquals(aCustomer.getAddress().get().getStreet(), aOutput.get().street());
+        Assertions.assertEquals(aCustomer.getAddress().get().getNumber(), aOutput.get().number());
+        Assertions.assertEquals(aCustomer.getAddress().get().getComplement(), aOutput.get().complement());
+        Assertions.assertEquals(aCustomer.getAddress().get().getDistrict(), aOutput.get().district());
+        Assertions.assertEquals(aCustomer.getAddress().get().getCity(), aOutput.get().city());
+        Assertions.assertEquals(aCustomer.getAddress().get().getState(), aOutput.get().state());
+    }
+
+    @Test
+    void givenAnInvalidAccountId_whenFindCustomerByAccountId_thenReturnEmpty() {
+        final var aCustomerId = "invalid-account-id";
+
+        Mockito.when(getCustomerByAccountIdUseCase.execute(aCustomerId))
+                .thenThrow(NotFoundException.with(Customer.class, aCustomerId).get());
+
+        final var aOutput = orderCustomerGatewayImpl.findByCustomerId(aCustomerId);
+
+        Assertions.assertTrue(aOutput.isEmpty());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderDeliveryMySQLGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderDeliveryMySQLGatewayTest.java
@@ -1,0 +1,51 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.domain.order.OrderDelivery;
+import com.kaua.ecommerce.infrastructure.DatabaseGatewayTest;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntityRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DatabaseGatewayTest
+public class OrderDeliveryMySQLGatewayTest {
+
+    @Autowired
+    private OrderDeliveryMySQLGateway orderDeliveryMySQLGateway;
+
+    @Autowired
+    private OrderDeliveryJpaEntityRepository orderDeliveryJpaEntityRepository;
+
+    @Test
+    void givenAValidOrderDelivery_whenCallCreate_thenOrderDeliveryIsPersisted() {
+        final var aFreightType = "SEDEX";
+        final var aFreightPrice = 10.0f;
+        final var aDeliveryEstimatedDays = 3;
+        final var aDeliveryStreet = "Rua dos Bobos";
+        final var aDeliveryNumber = "0";
+        final var aDeliveryComplement = "Apto 123";
+        final var aDeliveryDistrict = "Centro";
+        final var aDeliveryCity = "São Paulo";
+        final var aDeliveryState = "SP";
+        final var aDeliveryZipCode = "00000-000";
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                aFreightType,
+                aFreightPrice,
+                aDeliveryEstimatedDays,
+                aDeliveryStreet,
+                aDeliveryNumber,
+                aDeliveryComplement,
+                aDeliveryDistrict,
+                aDeliveryCity,
+                aDeliveryState,
+                aDeliveryZipCode
+        );
+
+        Assertions.assertEquals(0, this.orderDeliveryJpaEntityRepository.count());
+
+        this.orderDeliveryMySQLGateway.create(aOrderDelivery);
+
+        Assertions.assertEquals(1, this.orderDeliveryJpaEntityRepository.count());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderFreightGatewayImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderFreightGatewayImplTest.java
@@ -1,0 +1,56 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.application.gateways.order.OrderFreightGateway;
+import com.kaua.ecommerce.application.usecases.freight.calculate.CalculateFreightUseCase;
+import com.kaua.ecommerce.domain.freight.Freight;
+import com.kaua.ecommerce.domain.freight.FreightType;
+import com.kaua.ecommerce.infrastructure.IntegrationTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Set;
+
+@IntegrationTest
+public class OrderFreightGatewayImplTest {
+
+    @MockBean
+    private CalculateFreightUseCase calculateFreightUseCase;
+
+    @Autowired
+    private OrderFreightGatewayImpl orderFreightGatewayImpl;
+
+    @Test
+    void givenAValidInput_whenCallCalculateFreight_thenReturnOrderFreightDetails() {
+        final var aZipCode = "12345678";
+        final var aType = "PAC";
+        final var aHeight = 15.0;
+        final var aWidth = 30.0;
+        final var aLength = 45.0;
+        final var aWeight = 55.5;
+
+        final var aFreight = Freight.newFreight(aZipCode, FreightType.PAC, 10.0f, 3);
+
+        final var aCommand = new OrderFreightGateway.CalculateOrderFreightInput(
+                aZipCode,
+                aType,
+                Set.of(new OrderFreightGateway.CalculateOrderFreightItemsInput(
+                        aWeight,
+                        aWidth,
+                        aHeight,
+                        aLength
+                ))
+        );
+
+        Mockito.when(this.calculateFreightUseCase.execute(Mockito.any()))
+                .thenReturn(aFreight);
+
+        final var aOutput = this.orderFreightGatewayImpl.calculateFreight(aCommand);
+
+        Assertions.assertEquals(aFreight.getType().name(), aOutput.type());
+        Assertions.assertEquals(aFreight.getPrice(), aOutput.price());
+        Assertions.assertEquals(aFreight.getDeadline(), aOutput.deadlineInDays());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderMySQLGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderMySQLGatewayTest.java
@@ -1,0 +1,119 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.domain.order.*;
+import com.kaua.ecommerce.domain.utils.IdUtils;
+import com.kaua.ecommerce.infrastructure.DatabaseGatewayTest;
+import com.kaua.ecommerce.infrastructure.order.persistence.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+@DatabaseGatewayTest
+public class OrderMySQLGatewayTest {
+
+    @Autowired
+    private OrderMySQLGateway orderMySQLGateway;
+
+    @Autowired
+    private OrderJpaEntityRepository orderJpaEntityRepository;
+
+    @Autowired
+    private OrderDeliveryJpaEntityRepository orderDeliveryJpaEntityRepository;
+
+    @Autowired
+    private OrderPaymentJpaEntityRepository orderPaymentJpaEntityRepository;
+
+    @Autowired
+    private OrderItemJpaEntityRepository orderItemJpaEntityRepository;
+
+    @Test
+    void givenAValidOrder_whenCreateOrder_thenOrderIsPersisted() {
+        final var aCustomerId = "aCustomerId";
+        final var aCouponCode = "aCouponCode";
+        final var aCouponPercentage = 10.0F;
+
+        final var aOrderDelivery = OrderDelivery.newOrderDelivery(
+                "SEDEX",
+                10.0f,
+                5,
+                "aStreet",
+                "aNumber",
+                "aComplement",
+                "aDistrict",
+                "aCity",
+                "aState",
+                "aZipCode"
+        );
+        final var aOrderPayment = OrderPayment.newOrderPayment(
+                IdUtils.generateWithoutDash(),
+                0
+        );
+
+        final var aOrder = Order.newOrder(
+                OrderCode.create(1L),
+                aCustomerId,
+                aCouponCode,
+                aCouponPercentage,
+                aOrderDelivery,
+                aOrderPayment.getId()
+        );
+        aOrder.addItem(OrderItem.create(
+                aOrder.getId().getValue(),
+                "aProductId",
+                "aSku",
+                1,
+                BigDecimal.valueOf(10.0)
+        ));
+        aOrder.calculateTotalAmount(aOrderDelivery);
+
+        Assertions.assertEquals(0, this.orderJpaEntityRepository.count());
+        Assertions.assertEquals(0, this.orderDeliveryJpaEntityRepository.count());
+        Assertions.assertEquals(0, this.orderPaymentJpaEntityRepository.count());
+
+        this.orderMySQLGateway.createInBatch(aOrder.getOrderItems());
+        this.orderDeliveryJpaEntityRepository.save(OrderDeliveryJpaEntity.toEntity(aOrderDelivery));
+        this.orderPaymentJpaEntityRepository.save(OrderPaymentJpaEntity.toEntity(aOrderPayment));
+
+        final var aResult = this.orderMySQLGateway.create(aOrder);
+
+        Assertions.assertEquals(1, this.orderJpaEntityRepository.count());
+        Assertions.assertEquals(1, this.orderDeliveryJpaEntityRepository.count());
+        Assertions.assertEquals(1, this.orderPaymentJpaEntityRepository.count());
+        Assertions.assertEquals(aOrder.getId().getValue(), aResult.getId().getValue());
+    }
+
+    @Test
+    void testCallOrderCount() {
+        final var aCount = this.orderMySQLGateway.count();
+        Assertions.assertEquals(0, aCount);
+    }
+
+    @Test
+    void givenAValidOrderItems_whenCallCreateInBatch_thenOrderItemsArePersisted() {
+        final var aOrderItems = Set.of(
+                OrderItem.create(
+                        "aOrderId",
+                        "aProductId",
+                        "aSku",
+                        1,
+                        BigDecimal.valueOf(10.0)
+                ),
+                OrderItem.create(
+                        "aOrderId",
+                        "aProductId2",
+                        "aSku2",
+                        2,
+                        BigDecimal.valueOf(20.0)
+                )
+        );
+
+        Assertions.assertEquals(0, this.orderItemJpaEntityRepository.count());
+
+        this.orderMySQLGateway.createInBatch(aOrderItems);
+
+        Assertions.assertEquals(2, this.orderItemJpaEntityRepository.count());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderPaymentMySQLGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderPaymentMySQLGatewayTest.java
@@ -1,0 +1,33 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.domain.order.OrderPayment;
+import com.kaua.ecommerce.domain.utils.IdUtils;
+import com.kaua.ecommerce.infrastructure.DatabaseGatewayTest;
+import com.kaua.ecommerce.infrastructure.order.persistence.OrderPaymentJpaEntityRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DatabaseGatewayTest
+public class OrderPaymentMySQLGatewayTest {
+
+    @Autowired
+    private OrderPaymentMySQLGateway orderPaymentMySQLGateway;
+
+    @Autowired
+    private OrderPaymentJpaEntityRepository orderPaymentJpaEntityRepository;
+
+    @Test
+    void givenAValidOrderPayment_whenCallCreate_thenOrderPaymentIsPersisted() {
+        final var aPaymentMethodId = IdUtils.generateWithoutDash();
+        final var aInstallments = 3;
+
+        final var aOrderPayment = OrderPayment.newOrderPayment(aPaymentMethodId, aInstallments);
+
+        Assertions.assertEquals(0, this.orderPaymentJpaEntityRepository.count());
+
+        this.orderPaymentMySQLGateway.create(aOrderPayment);
+
+        Assertions.assertEquals(1, this.orderPaymentJpaEntityRepository.count());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderProductGatewayImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderProductGatewayImplTest.java
@@ -1,0 +1,18 @@
+package com.kaua.ecommerce.infrastructure.order;
+
+import com.kaua.ecommerce.infrastructure.IntegrationTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+public class OrderProductGatewayImplTest {
+
+    @Autowired
+    private OrderProductGatewayImpl orderProductGatewayImpl;
+
+    @Test
+    void testReturnEmptyOptionalWhenGetProductDetailsBySku() {
+        Assertions.assertTrue(orderProductGatewayImpl.getProductDetailsBySku("sku-123").isEmpty());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderDeliveryJpaEntityRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderDeliveryJpaEntityRepositoryTest.java
@@ -1,0 +1,242 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.infrastructure.DatabaseGatewayTest;
+import org.hibernate.PropertyValueException;
+import org.hibernate.id.IdentifierGenerationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.jpa.JpaSystemException;
+
+@DatabaseGatewayTest
+public class OrderDeliveryJpaEntityRepositoryTest {
+
+    @Autowired
+    private OrderDeliveryJpaEntityRepository orderDeliveryJpaEntityRepository;
+
+    @Test
+    void givenAnInvalidNullId_whenCallSave_shouldReturnAnException() {
+        final var expectedErrorMessage = "ids for this class must be manually assigned before calling save(): com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntity";
+
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setId(null);
+
+        final var actualException = Assertions.assertThrows(JpaSystemException.class,
+                () -> orderDeliveryJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(IdentifierGenerationException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullFreightType_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "freightType";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntity.freightType";
+
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setFreightType(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderDeliveryJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullStreet_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "street";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntity.street";
+
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setStreet(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderDeliveryJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullNumber_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "number";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntity.number";
+
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setNumber(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderDeliveryJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullCity_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "city";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntity.city";
+
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setCity(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderDeliveryJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullState_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "state";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntity.state";
+
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setState(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderDeliveryJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullZipCode_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "zipCode";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntity.zipCode";
+
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setZipCode(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderDeliveryJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAValidZeroFreightPrice_whenCallSave_shouldReturnOrderDelivery() {
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setFreightPrice(0.0f);
+
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderDeliveryJpaEntityRepository.save(aEntity).toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getId().getValue());
+        Assertions.assertEquals(aEntity.getFreightType(), actualResult.getFreightType());
+        Assertions.assertEquals(aEntity.getStreet(), actualResult.getStreet());
+        Assertions.assertEquals(aEntity.getNumber(), actualResult.getNumber());
+        Assertions.assertEquals(aEntity.getCity(), actualResult.getCity());
+        Assertions.assertEquals(aEntity.getState(), actualResult.getState());
+        Assertions.assertEquals(aEntity.getZipCode(), actualResult.getZipCode());
+        Assertions.assertEquals(aEntity.getFreightPrice(), actualResult.getFreightPrice());
+    }
+
+    @Test
+    void givenAValidOrderDelivery_whenCallSaveAndToDomain_shouldReturnOrderDelivery() {
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderDeliveryJpaEntityRepository.save(aEntity).toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getId().getValue());
+        Assertions.assertEquals(aEntity.getFreightType(), actualResult.getFreightType());
+        Assertions.assertEquals(aEntity.getStreet(), actualResult.getStreet());
+        Assertions.assertEquals(aEntity.getNumber(), actualResult.getNumber());
+        Assertions.assertEquals(aEntity.getCity(), actualResult.getCity());
+        Assertions.assertEquals(aEntity.getState(), actualResult.getState());
+        Assertions.assertEquals(aEntity.getZipCode(), actualResult.getZipCode());
+        Assertions.assertEquals(aEntity.getFreightPrice(), actualResult.getFreightPrice());
+    }
+
+    @Test
+    void givenAValidDeliveryEstimated_whenCallSave_shouldReturnOrderDelivery() {
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setDeliveryEstimated(1);
+
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderDeliveryJpaEntityRepository.save(aEntity).toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getId().getValue());
+        Assertions.assertEquals(aEntity.getFreightType(), actualResult.getFreightType());
+        Assertions.assertEquals(aEntity.getStreet(), actualResult.getStreet());
+        Assertions.assertEquals(aEntity.getNumber(), actualResult.getNumber());
+        Assertions.assertEquals(aEntity.getCity(), actualResult.getCity());
+        Assertions.assertEquals(aEntity.getState(), actualResult.getState());
+        Assertions.assertEquals(aEntity.getZipCode(), actualResult.getZipCode());
+        Assertions.assertEquals(aEntity.getFreightPrice(), actualResult.getFreightPrice());
+        Assertions.assertEquals(aEntity.getDeliveryEstimated(), actualResult.getDeliveryEstimated());
+    }
+
+    @Test
+    void givenAValidNullComplement_whenCallSave_shouldReturnOrderDelivery() {
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setComplement(null);
+
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderDeliveryJpaEntityRepository.save(aEntity).toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getId().getValue());
+        Assertions.assertEquals(aEntity.getFreightType(), actualResult.getFreightType());
+        Assertions.assertEquals(aEntity.getStreet(), actualResult.getStreet());
+        Assertions.assertEquals(aEntity.getNumber(), actualResult.getNumber());
+        Assertions.assertEquals(aEntity.getCity(), actualResult.getCity());
+        Assertions.assertEquals(aEntity.getState(), actualResult.getState());
+        Assertions.assertEquals(aEntity.getZipCode(), actualResult.getZipCode());
+        Assertions.assertEquals(aEntity.getFreightPrice(), actualResult.getFreightPrice());
+        Assertions.assertEquals(aEntity.getDeliveryEstimated(), actualResult.getDeliveryEstimated());
+        Assertions.assertEquals(aEntity.getComplement(), actualResult.getComplement());
+    }
+
+    @Test
+    void givenAnInvalidNullDistrict_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "district";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderDeliveryJpaEntity.district";
+
+        final var aOrderDelivery = Fixture.Orders.orderDelivery();
+        final var aEntity = OrderDeliveryJpaEntity.toEntity(aOrderDelivery);
+        aEntity.setDistrict(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderDeliveryJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderItemJpaEntityRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderItemJpaEntityRepositoryTest.java
@@ -1,0 +1,138 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.infrastructure.DatabaseGatewayTest;
+import org.hibernate.PropertyValueException;
+import org.hibernate.id.IdentifierGenerationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.jpa.JpaSystemException;
+
+@DatabaseGatewayTest
+public class OrderItemJpaEntityRepositoryTest {
+
+    @Autowired
+    private OrderItemJpaEntityRepository orderItemJpaEntityRepository;
+
+    @Test
+    void givenAnInvalidNullId_whenCallSave_shouldReturnAnException() {
+        final var expectedErrorMessage = "ids for this class must be manually assigned before calling save(): com.kaua.ecommerce.infrastructure.order.persistence.OrderItemJpaEntity";
+
+        final var aOrderItem = Fixture.Orders.orderItem();
+        final var aEntity = OrderItemJpaEntity.toEntity(aOrderItem);
+        aEntity.setId(null);
+
+        final var actualException = Assertions.assertThrows(JpaSystemException.class,
+                () -> orderItemJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(IdentifierGenerationException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullOrderId_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "orderId";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderItemJpaEntity.orderId";
+
+        final var aOrderItem = Fixture.Orders.orderItem();
+        final var aEntity = OrderItemJpaEntity.toEntity(aOrderItem);
+        aEntity.setOrderId(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderItemJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullProductId_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "productId";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderItemJpaEntity.productId";
+
+        final var aOrderItem = Fixture.Orders.orderItem();
+        final var aEntity = OrderItemJpaEntity.toEntity(aOrderItem);
+        aEntity.setProductId(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderItemJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullSku_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "sku";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderItemJpaEntity.sku";
+
+        final var aOrderItem = Fixture.Orders.orderItem();
+        final var aEntity = OrderItemJpaEntity.toEntity(aOrderItem);
+        aEntity.setSku(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderItemJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAValidOneInQuantity_whenCallSave_shouldReturnOrderItem() {
+        final var aOrderItem = Fixture.Orders.orderItem();
+        final var aEntity = OrderItemJpaEntity.toEntity(aOrderItem);
+        aEntity.setQuantity(1);
+
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderItemJpaEntityRepository.save(aEntity).toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getOrderItemId());
+        Assertions.assertEquals(aEntity.getOrderId(), actualResult.getOrderId());
+        Assertions.assertEquals(aEntity.getProductId(), actualResult.getProductId());
+        Assertions.assertEquals(aEntity.getQuantity(), actualResult.getQuantity());
+    }
+
+    @Test
+    void givenAValidOrderItem_whenCallSaveAndToDomain_shouldReturnOrderItem() {
+        final var aOrderItem = Fixture.Orders.orderItem();
+        final var aEntity = OrderItemJpaEntity.toEntity(aOrderItem);
+
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderItemJpaEntityRepository.save(aEntity).toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getOrderItemId());
+        Assertions.assertEquals(aEntity.getOrderId(), actualResult.getOrderId());
+        Assertions.assertEquals(aEntity.getProductId(), actualResult.getProductId());
+        Assertions.assertEquals(aEntity.getQuantity(), actualResult.getQuantity());
+    }
+
+    @Test
+    void givenAnInvalidNullPrice_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "price";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderItemJpaEntity.price";
+
+        final var aOrderItem = Fixture.Orders.orderItem();
+        final var aEntity = OrderItemJpaEntity.toEntity(aOrderItem);
+        aEntity.setPrice(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderItemJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderJpaEntityRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderJpaEntityRepositoryTest.java
@@ -1,0 +1,250 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.infrastructure.DatabaseGatewayTest;
+import org.hibernate.PropertyValueException;
+import org.hibernate.id.IdentifierGenerationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.jpa.JpaSystemException;
+
+import java.util.HashSet;
+
+@DatabaseGatewayTest
+public class OrderJpaEntityRepositoryTest {
+
+    @Autowired
+    private OrderJpaEntityRepository orderJpaEntityRepository;
+
+    @Autowired
+    private OrderItemJpaEntityRepository orderItemJpaEntityRepository;
+
+    @Test
+    void givenAnInvalidNullOrderCode_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "orderCode";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntity.orderCode";
+
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setOrderCode(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullCreatedAt_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "createdAt";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntity.createdAt";
+
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setCreatedAt(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullUpdatedAt_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "updatedAt";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntity.updatedAt";
+
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setUpdatedAt(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullId_whenCallSave_shouldReturnAnException() {
+        final var expectedErrorMessage = "ids for this class must be manually assigned before calling save(): com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntity";
+
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setId(null);
+
+        final var actualException = Assertions.assertThrows(JpaSystemException.class,
+                () -> orderJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(IdentifierGenerationException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullCustomerId_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "customerId";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntity.customerId";
+
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setCustomerId(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullStatus_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "status";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntity.status";
+
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setStatus(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullTotal_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "totalPrice";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntity.totalPrice";
+
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setTotalPrice(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAValidEmptyItems_whenCallSave_shouldReturnOrder() {
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setOrderItems(new HashSet<>());
+
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderJpaEntityRepository.save(aEntity).toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getId().getValue());
+        Assertions.assertEquals(aEntity.getOrderCode(), actualResult.getOrderCode().getValue());
+        Assertions.assertEquals(aEntity.getCustomerId(), actualResult.getCustomerId());
+        Assertions.assertEquals(aEntity.getStatus(), actualResult.getOrderStatus());
+        Assertions.assertEquals(aEntity.getTotalPrice(), actualResult.getTotalAmount());
+        Assertions.assertTrue(actualResult.getOrderItems().isEmpty());
+        Assertions.assertEquals(aEntity.getCreatedAt(), actualResult.getCreatedAt());
+        Assertions.assertEquals(aEntity.getUpdatedAt(), actualResult.getUpdatedAt());
+    }
+
+    @Test
+    void givenAValidOrder_whenCallSaveAndToDomain_shouldReturnOrder() {
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+
+        Assertions.assertDoesNotThrow(() -> orderItemJpaEntityRepository.saveAll(aEntity.getOrderItems()));
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderJpaEntityRepository.save(aEntity)
+                .toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getId().getValue());
+        Assertions.assertEquals(aEntity.getOrderCode(), actualResult.getOrderCode().getValue());
+        Assertions.assertEquals(aEntity.getCustomerId(), actualResult.getCustomerId());
+        Assertions.assertEquals(aEntity.getStatus(), actualResult.getOrderStatus());
+        Assertions.assertEquals(aEntity.getTotalPrice(), actualResult.getTotalAmount());
+        Assertions.assertEquals(aEntity.getOrderItems().size(), actualResult.getOrderItems().size());
+        Assertions.assertEquals(aEntity.getCreatedAt(), actualResult.getCreatedAt());
+        Assertions.assertEquals(aEntity.getUpdatedAt(), actualResult.getUpdatedAt());
+    }
+
+    @Test
+    void givenAValidNullCouponCodeAndZeroCouponPercentage_whenCallSave_shouldReturnOrder() {
+        final var aOrder = Fixture.Orders.orderWithoutCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setCouponCode(null);
+        aEntity.setCouponPercentage(0.0f);
+
+        Assertions.assertDoesNotThrow(() -> orderItemJpaEntityRepository.saveAll(aEntity.getOrderItems()));
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderJpaEntityRepository.save(aEntity)
+                .toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getId().getValue());
+        Assertions.assertEquals(aEntity.getOrderCode(), actualResult.getOrderCode().getValue());
+        Assertions.assertEquals(aEntity.getCustomerId(), actualResult.getCustomerId());
+        Assertions.assertEquals(aEntity.getStatus(), actualResult.getOrderStatus());
+        Assertions.assertEquals(aEntity.getTotalPrice(), actualResult.getTotalAmount());
+        Assertions.assertEquals(aEntity.getOrderItems().size(), actualResult.getOrderItems().size());
+        Assertions.assertEquals(aEntity.getCreatedAt(), actualResult.getCreatedAt());
+        Assertions.assertEquals(aEntity.getUpdatedAt(), actualResult.getUpdatedAt());
+    }
+
+    @Test
+    void givenAnInvalidNullOrderDeliveryId_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "orderDeliveryId";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntity.orderDeliveryId";
+
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setOrderDeliveryId(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullOrderPaymentId_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "orderPaymentId";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderJpaEntity.orderPaymentId";
+
+        final var aOrder = Fixture.Orders.orderWithCoupon();
+        final var aEntity = OrderJpaEntity.toEntity(aOrder);
+        aEntity.setOrderPaymentId(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderPaymentJpaEntityRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/persistence/OrderPaymentJpaEntityRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.kaua.ecommerce.infrastructure.order.persistence;
+
+import com.kaua.ecommerce.domain.Fixture;
+import com.kaua.ecommerce.infrastructure.DatabaseGatewayTest;
+import org.hibernate.PropertyValueException;
+import org.hibernate.id.IdentifierGenerationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.jpa.JpaSystemException;
+
+@DatabaseGatewayTest
+public class OrderPaymentJpaEntityRepositoryTest {
+
+    @Autowired
+    private OrderPaymentJpaEntityRepository orderPaymentJpaEntityRepository;
+
+    @Test
+    void givenAnInvalidNullId_whenCallSave_shouldReturnAnException() {
+        final var expectedErrorMessage = "ids for this class must be manually assigned before calling save(): com.kaua.ecommerce.infrastructure.order.persistence.OrderPaymentJpaEntity";
+
+        final var aOrderPayment = Fixture.Orders.orderPaymentWithZeroInstallments();
+        final var aEntity = OrderPaymentJpaEntity.toEntity(aOrderPayment);
+        aEntity.setId(null);
+
+        final var actualException = Assertions.assertThrows(JpaSystemException.class,
+                () -> orderPaymentJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(IdentifierGenerationException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAnInvalidNullPaymentMethodId_whenCallSave_shouldReturnAnException() {
+        final var expectedPropertyName = "paymentMethodId";
+        final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.infrastructure.order.persistence.OrderPaymentJpaEntity.paymentMethodId";
+
+        final var aOrderPayment = Fixture.Orders.orderPaymentWithZeroInstallments();
+        final var aEntity = OrderPaymentJpaEntity.toEntity(aOrderPayment);
+        aEntity.setPaymentMethodId(null);
+
+        final var actualException = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> orderPaymentJpaEntityRepository.save(aEntity));
+
+        final var actualCause = Assertions.assertInstanceOf(PropertyValueException.class,
+                actualException.getCause());
+
+        Assertions.assertEquals(expectedPropertyName, actualCause.getPropertyName());
+        Assertions.assertEquals(expectedErrorMessage, actualCause.getMessage());
+    }
+
+    @Test
+    void givenAValidZeroInstallments_whenCallSave_shouldReturnOrderPayment() {
+        final var aOrderPayment = Fixture.Orders.orderPaymentWithZeroInstallments();
+        final var aEntity = OrderPaymentJpaEntity.toEntity(aOrderPayment);
+        aEntity.setInstallments(0);
+
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderPaymentJpaEntityRepository.save(aEntity).toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getId().getValue());
+        Assertions.assertEquals(aEntity.getPaymentMethodId(), actualResult.getPaymentMethodId());
+        Assertions.assertEquals(aEntity.getInstallments(), actualResult.getInstallments());
+    }
+
+    @Test
+    void givenAValidOrderPayment_whenCallSaveAndToDomain_shouldReturnOrderPayment() {
+        final var aOrderPayment = Fixture.Orders.orderPaymentWithZeroInstallments();
+        final var aEntity = OrderPaymentJpaEntity.toEntity(aOrderPayment);
+
+        final var actualResult = Assertions.assertDoesNotThrow(() -> orderPaymentJpaEntityRepository.save(aEntity).toDomain());
+
+        Assertions.assertEquals(aEntity.getId(), actualResult.getId().getValue());
+        Assertions.assertEquals(aEntity.getPaymentMethodId(), actualResult.getPaymentMethodId());
+        Assertions.assertEquals(aEntity.getInstallments(), actualResult.getInstallments());
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/service/impl/S3StorageServiceImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/service/impl/S3StorageServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.kaua.ecommerce.infrastructure.service.impl;
 
 import com.kaua.ecommerce.domain.utils.IdUtils;
-import com.kaua.ecommerce.domain.utils.Resource;
+import com.kaua.ecommerce.domain.resource.Resource;
 import com.kaua.ecommerce.infrastructure.IntegrationTest;
 import com.kaua.ecommerce.infrastructure.exceptions.FileStorageException;
 import org.junit.jupiter.api.Assertions;

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/service/local/InMemoryStorageServiceImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/service/local/InMemoryStorageServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.kaua.ecommerce.infrastructure.service.local;
 
 import com.kaua.ecommerce.domain.utils.IdUtils;
-import com.kaua.ecommerce.domain.utils.Resource;
+import com.kaua.ecommerce.domain.resource.Resource;
 import com.kaua.ecommerce.infrastructure.UnitTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## Descrição

Foi adicionado a feature para criar uma order junto com a feature para calcular o frete

## Mudanças Propostas

N/A

## Testes Realizados

Testes de unidade e integração

## Cobertura de Testes

O mínimo é 95%, está em 100%

## Problemas Conhecidos

Hoje o cupom não possui um valor mínimo de uso, então posso usar um cupom de 100 reais em uma compra de 10 reais. O getProductDetailsBySku não está implementado, o certo é implementar um usecase pra isso. Refatorar o usecase de remove coupon slot pra talvez apply coupon. Precisamos publicar o evento de orderPlaced. Remover o CDC com debezium e configurar um job pra buscar no database, então podemos melhorar a parte dos eventos, adicionar headers, como o occurredOn e id / version. Melhorar o consumer do kafka pra evitar processar eventos mais antigos, adicionar mais tratamentos com nack quando não encontrar pelo id, sku ou o que seja.

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
