### PR TITLE
Refactor/create order usecase

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderCouponGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/application/gateways/order/OrderCouponGateway.java
@@ -2,7 +2,7 @@ package com.kaua.ecommerce.application.gateways.order;
 
 public interface OrderCouponGateway {
 
-    OrderCouponApplyOutput applyCoupon(String couponCode);
+    OrderCouponApplyOutput applyCoupon(String couponCode, float totalAmount);
 
     record OrderCouponApplyOutput(
             String couponId,

--- a/application/src/test/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/application/usecases/order/create/CreateOrderUseCaseTest.java
@@ -96,7 +96,7 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
                 .thenReturn(Optional.of(createOrderProductDetailsOutput("bola", BigDecimal.valueOf(200.0))));
         Mockito.when(orderFreightGateway.calculateFreight(Mockito.any()))
                 .thenReturn(createOrderFreightDetails());
-        Mockito.when(orderCouponGateway.applyCoupon(aCouponCode))
+        Mockito.when(orderCouponGateway.applyCoupon(Mockito.anyString(), Mockito.anyFloat()))
                 .thenReturn(createOrderCouponOutput(aCoupon));
         Mockito.when(orderGateway.count())
                 .thenReturn(1L);
@@ -120,7 +120,7 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
         Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
         Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
         Mockito.verify(orderFreightGateway, Mockito.times(1)).calculateFreight(Mockito.any());
-        Mockito.verify(orderCouponGateway, Mockito.times(1)).applyCoupon(aCouponCode);
+        Mockito.verify(orderCouponGateway, Mockito.times(1)).applyCoupon(Mockito.anyString(), Mockito.anyFloat());
         Mockito.verify(orderGateway, Mockito.times(1)).count();
         Mockito.verify(orderGateway, Mockito.times(1))
                 .createInBatch(argThat(it -> it.size() == aItems.size()));
@@ -201,7 +201,7 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
         Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
         Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
         Mockito.verify(orderFreightGateway, Mockito.times(1)).calculateFreight(Mockito.any());
-        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any(), Mockito.anyFloat());
         Mockito.verify(orderGateway, Mockito.times(1)).count();
         Mockito.verify(orderGateway, Mockito.times(1))
                 .createInBatch(argThat(it -> it.size() == aItems.size()));
@@ -282,7 +282,7 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
         Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
         Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
         Mockito.verify(orderFreightGateway, Mockito.times(1)).calculateFreight(Mockito.any());
-        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any(), Mockito.anyFloat());
         Mockito.verify(orderGateway, Mockito.times(1)).count();
         Mockito.verify(orderGateway, Mockito.times(1))
                 .createInBatch(argThat(it -> it.size() == aItems.size()));
@@ -344,7 +344,7 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
                 .thenReturn(Optional.of(createOrderProductDetailsOutput("bola", BigDecimal.valueOf(200.0))));
         Mockito.when(orderFreightGateway.calculateFreight(Mockito.any()))
                 .thenReturn(createOrderFreightDetails());
-        Mockito.when(orderCouponGateway.applyCoupon(aCouponCode))
+        Mockito.when(orderCouponGateway.applyCoupon(Mockito.anyString(), Mockito.anyFloat()))
                 .thenReturn(createOrderCouponOutput(aCoupon));
         Mockito.when(orderGateway.count())
                 .thenReturn(1L);
@@ -360,7 +360,7 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
         Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
         Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
         Mockito.verify(orderFreightGateway, Mockito.times(1)).calculateFreight(Mockito.any());
-        Mockito.verify(orderCouponGateway, Mockito.times(1)).applyCoupon(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(1)).applyCoupon(Mockito.any(), Mockito.anyFloat());
         Mockito.verify(orderGateway, Mockito.times(1)).count();
         Mockito.verify(orderGateway, Mockito.times(0)).createInBatch(Mockito.any());
         Mockito.verify(orderDeliveryGateway, Mockito.times(0)).create(Mockito.any());
@@ -407,10 +407,10 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
                 .thenReturn(Optional.of(createOrderProductDetailsOutput("bola", BigDecimal.valueOf(200.0))));
         Mockito.when(orderFreightGateway.calculateFreight(Mockito.any()))
                 .thenReturn(createOrderFreightDetails());
-        Mockito.when(orderCouponGateway.applyCoupon(aCouponCode))
-                .thenReturn(createOrderCouponOutput(aCoupon));
         Mockito.when(orderGateway.count())
                 .thenReturn(1L);
+        Mockito.when(orderCouponGateway.applyCoupon(Mockito.anyString(), Mockito.anyFloat()))
+                .thenReturn(createOrderCouponOutput(aCoupon));
 
         final var aOutput = this.createOrderUseCase.execute(aCommand).getLeft();
 
@@ -421,7 +421,7 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
         Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
         Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
         Mockito.verify(orderFreightGateway, Mockito.times(1)).calculateFreight(Mockito.any());
-        Mockito.verify(orderCouponGateway, Mockito.times(1)).applyCoupon(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(1)).applyCoupon(Mockito.any(), Mockito.anyFloat());
         Mockito.verify(orderGateway, Mockito.times(1)).count();
         Mockito.verify(orderGateway, Mockito.times(0)).createInBatch(Mockito.any());
         Mockito.verify(orderDeliveryGateway, Mockito.times(0)).create(Mockito.any());
@@ -473,7 +473,7 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
         Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
         Mockito.verify(orderProductGateway, Mockito.times(0)).getProductDetailsBySku(Mockito.any());
         Mockito.verify(orderFreightGateway, Mockito.times(0)).calculateFreight(Mockito.any());
-        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any(), Mockito.anyFloat());
         Mockito.verify(orderGateway, Mockito.times(0)).count();
         Mockito.verify(orderGateway, Mockito.times(0)).createInBatch(Mockito.any());
         Mockito.verify(orderDeliveryGateway, Mockito.times(0)).create(Mockito.any());
@@ -531,7 +531,7 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
         Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
         Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
         Mockito.verify(orderFreightGateway, Mockito.times(0)).calculateFreight(Mockito.any());
-        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any(), Mockito.anyFloat());
         Mockito.verify(orderGateway, Mockito.times(0)).count();
         Mockito.verify(orderGateway, Mockito.times(0)).createInBatch(Mockito.any());
         Mockito.verify(orderDeliveryGateway, Mockito.times(0)).create(Mockito.any());
@@ -589,7 +589,7 @@ public class CreateOrderUseCaseTest extends UseCaseTest {
         Mockito.verify(orderCustomerGateway, Mockito.times(1)).findByCustomerId(aCustomerId);
         Mockito.verify(orderProductGateway, Mockito.times(2)).getProductDetailsBySku(Mockito.any());
         Mockito.verify(orderFreightGateway, Mockito.times(0)).calculateFreight(Mockito.any());
-        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any());
+        Mockito.verify(orderCouponGateway, Mockito.times(0)).applyCoupon(Mockito.any(), Mockito.anyFloat());
         Mockito.verify(orderGateway, Mockito.times(0)).count();
         Mockito.verify(orderGateway, Mockito.times(0)).createInBatch(Mockito.any());
         Mockito.verify(orderDeliveryGateway, Mockito.times(0)).create(Mockito.any());

--- a/domain/src/main/java/com/kaua/ecommerce/domain/order/Order.java
+++ b/domain/src/main/java/com/kaua/ecommerce/domain/order/Order.java
@@ -26,11 +26,11 @@ public class Order extends AggregateRoot<OrderID> {
     private final OrderStatus orderStatus;
     private final Set<OrderItem> orderItems;
     private final String customerId;
-    private final String couponCode;
-    private final float couponPercentage;
     private final OrderDeliveryID orderDeliveryId;
     private final OrderPaymentID orderPaymentId;
     private final Instant createdAt;
+    private String couponCode;
+    private float couponPercentage;
     private BigDecimal totalAmount;
     private Instant updatedAt;
 
@@ -66,8 +66,6 @@ public class Order extends AggregateRoot<OrderID> {
     public static Order newOrder(
             final OrderCode aOrderCode,
             final String aCustomerId,
-            final String aCouponCode,
-            final float aCouponPercentage,
             final OrderDelivery aOrderDelivery,
             final OrderPaymentID aOrderPaymentId
     ) {
@@ -86,8 +84,8 @@ public class Order extends AggregateRoot<OrderID> {
                 new HashSet<>(),
                 BigDecimal.ZERO,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
+                null,
+                0.0f,
                 aOrderDelivery.getId(),
                 aOrderPaymentId,
                 aNow,
@@ -151,7 +149,15 @@ public class Order extends AggregateRoot<OrderID> {
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
 
         this.totalAmount = this.totalAmount.add(BigDecimal.valueOf(aOrderDelivery.getFreightPrice()));
+    }
 
+    public void applyCoupon(final String aCouponCode, final float aCouponPercentage) {
+        this.couponCode = aCouponCode;
+        this.couponPercentage = aCouponPercentage;
+        applyCouponDiscount();
+    }
+
+    private void applyCouponDiscount() {
         if (this.getCouponCode().isPresent()) {
             this.totalAmount = this.totalAmount.subtract(this.totalAmount
                     .multiply(BigDecimal.valueOf(this.couponPercentage / 100)));

--- a/domain/src/test/java/com/kaua/ecommerce/domain/Fixture.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/Fixture.java
@@ -405,8 +405,6 @@ public final class Fixture {
         private static final Order ORDER_WITH_COUPON = Order.newOrder(
                 OrderCode.create(faker.random().nextLong(0, 999999)),
                 IdUtils.generate(),
-                "coupon-code",
-                10.0f,
                 ORDER_DELIVERY,
                 OrderPaymentID.unique()
         );
@@ -420,8 +418,6 @@ public final class Fixture {
         private static final Order ORDER_WITHOUT_COUPON = Order.newOrder(
                 OrderCode.create(faker.random().nextLong(0, 999999)),
                 IdUtils.generate(),
-                null,
-                0.0f,
                 ORDER_DELIVERY,
                 OrderPaymentID.unique()
         );
@@ -438,6 +434,7 @@ public final class Fixture {
                     BigDecimal.valueOf(100.0)
             ));
             ORDER_WITH_COUPON.calculateTotalAmount(ORDER_DELIVERY);
+            ORDER_WITH_COUPON.applyCoupon("BLACK_FRIDAY", 10.0f);
             return Order.with(ORDER_WITH_COUPON);
         }
 

--- a/domain/src/test/java/com/kaua/ecommerce/domain/order/OrderTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/order/OrderTest.java
@@ -17,9 +17,9 @@ public class OrderTest extends UnitTest {
     void givenAValidValues_whenCallNewOrder_shouldCreateNewOrder() {
         final var aSequence = 0;
         final var aCustomerId = "aCustomerId";
+        final var aOrderCode = OrderCode.create(aSequence);
         final var aCouponCode = "aCouponCode";
         final var aCouponPercentage = 10.0F;
-        final var aOrderCode = OrderCode.create(aSequence);
 
         final var aOrderDelivery = OrderDelivery.newOrderDelivery(
                 "sedex",
@@ -42,8 +42,6 @@ public class OrderTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 aOrderPayment.getId()
         );
@@ -67,6 +65,7 @@ public class OrderTest extends UnitTest {
         aOrder.addItem(aItemTwo);
 
         aOrder.calculateTotalAmount(aOrderDelivery);
+        aOrder.applyCoupon(aCouponCode, aCouponPercentage);
 
         Assertions.assertEquals(aOrderCode, aOrder.getOrderCode());
         Assertions.assertEquals(2, aOrder.getOrderItems().size());
@@ -175,8 +174,6 @@ public class OrderTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                null,
-                0,
                 aOrderDelivery,
                 aOrderPayment.getId()
         );
@@ -267,8 +264,6 @@ public class OrderTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 aOrderPayment.getId()
         );
@@ -292,6 +287,7 @@ public class OrderTest extends UnitTest {
         aOrder.addItem(aItemTwo);
 
         aOrder.calculateTotalAmount(aOrderDelivery);
+        aOrder.applyCoupon(aCouponCode, aCouponPercentage);
 
         final var aExpected = "Order(" +
                 "id=" + aOrder.getId().getValue() +
@@ -332,5 +328,15 @@ public class OrderTest extends UnitTest {
         Assertions.assertEquals(aOrder.getCreatedAt(), aOrderWith.getCreatedAt());
         Assertions.assertEquals(aOrder.getUpdatedAt(), aOrderWith.getUpdatedAt());
         Assertions.assertDoesNotThrow(() -> aOrderWith.validate(new ThrowsValidationHandler()));
+    }
+
+    @Test
+    void givenAValidOrder_whenCallApplyCouponWithNull_shouldNotApplyCoupon() {
+        final var aOrder = Fixture.Orders.orderWithoutCoupon();
+
+        aOrder.applyCoupon(null, 0.0F);
+
+        Assertions.assertTrue(aOrder.getCouponCode().isEmpty());
+        Assertions.assertEquals(0.0f, aOrder.getCouponPercentage());
     }
 }

--- a/domain/src/test/java/com/kaua/ecommerce/domain/order/validations/OrderValidationTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/domain/order/validations/OrderValidationTest.java
@@ -18,8 +18,6 @@ public class OrderValidationTest extends UnitTest {
     void givenAInvalidDuplicatedSku_whenCallNewOrder_shouldThrowsNotAcceptDuplicatedItemsException() {
         final var aSequence = 0;
         final var aCustomerId = "aCustomerId";
-        final var aCouponCode = "aCouponCode";
-        final var aCouponPercentage = 10.0F;
         final var aOrderCode = OrderCode.create(aSequence);
 
         final var expectedErrorMessage = "The item with SKU aSkuOne is already in the order";
@@ -64,8 +62,6 @@ public class OrderValidationTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 aOrderPaymentId
         );
@@ -80,8 +76,6 @@ public class OrderValidationTest extends UnitTest {
     void givenInvalidBlankCustomerId_whenCallNewOrder_shouldReturnDomainException() {
         final var aSequence = 0;
         final var aCustomerId = " ";
-        final var aCouponCode = "aCouponCode";
-        final var aCouponPercentage = 10.0F;
         final var aOrderCode = OrderCode.create(aSequence);
         final var aItem = OrderItem.create(
                 "aOrderId",
@@ -113,8 +107,6 @@ public class OrderValidationTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 aOrderPayment.getId()
         );
@@ -132,8 +124,6 @@ public class OrderValidationTest extends UnitTest {
     void givenInvalidNullCustomerId_whenCallNewOrder_shouldReturnDomainException() {
         final var aSequence = 0;
         final String aCustomerId = null;
-        final var aCouponCode = "aCouponCode";
-        final var aCouponPercentage = 10.0F;
         final var aOrderCode = OrderCode.create(aSequence);
         final var aItem = OrderItem.create(
                 "aOrderId",
@@ -165,8 +155,6 @@ public class OrderValidationTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 aOrderPayment.getId()
         );
@@ -181,11 +169,11 @@ public class OrderValidationTest extends UnitTest {
     }
 
     @Test
-    void givenInvalidBlankCouponCode_whenCallNewOrder_shouldReturnDomainException() {
+    void givenInvalidBlankCouponCode_whenCallApplyCoupon_shouldReturnDomainException() {
         final var aSequence = 0;
         final var aCustomerId = "aCustomerId";
         final var aCouponCode = " ";
-        final var aCouponPercentage = 10.0F;
+        final var aCouponPercentage = 0.0F;
         final var aOrderCode = OrderCode.create(aSequence);
         final var aItem = OrderItem.create(
                 "aOrderId",
@@ -217,13 +205,12 @@ public class OrderValidationTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 aOrderPayment.getId()
         );
         aOrder.addItem(aItem);
         aOrder.calculateTotalAmount(aOrderDelivery);
+        aOrder.applyCoupon(aCouponCode, aCouponPercentage);
 
         final var aTestValidationHandler = new TestValidationHandler();
         aOrder.validate(aTestValidationHandler);
@@ -233,7 +220,7 @@ public class OrderValidationTest extends UnitTest {
     }
 
     @Test
-    void givenInvalidNegativeCouponPercentage_whenCallNewOrder_shouldReturnDomainException() {
+    void givenInvalidNegativeCouponPercentage_whenCallApplyCoupon_shouldReturnDomainException() {
         final var aSequence = 0;
         final var aCustomerId = "aCustomerId";
         final var aCouponCode = "aCouponCode";
@@ -269,13 +256,12 @@ public class OrderValidationTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 aOrderPayment.getId()
         );
         aOrder.addItem(aItem);
         aOrder.calculateTotalAmount(aOrderDelivery);
+        aOrder.applyCoupon(aCouponCode, aCouponPercentage);
 
         final var aTestValidationHandler = new TestValidationHandler();
         aOrder.validate(aTestValidationHandler);
@@ -288,8 +274,6 @@ public class OrderValidationTest extends UnitTest {
     void givenInvalidNullOrderDeliveryId_whenCallNewOrder_shouldReturnDomainException() {
         final var aSequence = 0;
         final var aCustomerId = "aCustomerId";
-        final var aCouponCode = "aCouponCode";
-        final var aCouponPercentage = 10.0F;
         final var aOrderCode = OrderCode.create(aSequence);
         final var aOrderPayment = OrderPayment.newOrderPayment(
                 "aPaymentMethodId",
@@ -303,8 +287,6 @@ public class OrderValidationTest extends UnitTest {
                 () -> Order.newOrder(
                         aOrderCode,
                         aCustomerId,
-                        aCouponCode,
-                        aCouponPercentage,
                         null,
                         aOrderPayment.getId()
                 ));
@@ -317,8 +299,6 @@ public class OrderValidationTest extends UnitTest {
     void givenInvalidNullOrderPaymentId_whenCallNewOrder_shouldReturnDomainException() {
         final var aSequence = 0;
         final var aCustomerId = "aCustomerId";
-        final var aCouponCode = "aCouponCode";
-        final var aCouponPercentage = 10.0F;
         final var aOrderCode = OrderCode.create(aSequence);
         final var aItem = OrderItem.create(
                 "aOrderId",
@@ -346,8 +326,6 @@ public class OrderValidationTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 null
         );
@@ -393,8 +371,6 @@ public class OrderValidationTest extends UnitTest {
     void givenInvalidZeroOrderItem_whenCallValidate_shouldReturnDomainException() {
         final var aSequence = 0;
         final var aCustomerId = "aCustomerId";
-        final var aCouponCode = "aCouponCode";
-        final var aCouponPercentage = 10.0F;
         final var aOrderCode = OrderCode.create(aSequence);
         final var aOrderDelivery = OrderDelivery.newOrderDelivery(
                 "sedex",
@@ -419,8 +395,6 @@ public class OrderValidationTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 aOrderPayment.getId()
         );
@@ -436,8 +410,6 @@ public class OrderValidationTest extends UnitTest {
     void givenValidOrderWithItemsButNotCallCalculate_whenCallValidate_shouldReturnDomainException() {
         final var aSequence = 0;
         final var aCustomerId = "aCustomerId";
-        final var aCouponCode = "aCouponCode";
-        final var aCouponPercentage = 10.0F;
         final var aOrderCode = OrderCode.create(aSequence);
         final var aItem = OrderItem.create(
                 "aOrderId",
@@ -469,8 +441,6 @@ public class OrderValidationTest extends UnitTest {
         final var aOrder = Order.newOrder(
                 aOrderCode,
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 aOrderPayment.getId()
         );

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/api/controllers/OrderController.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/api/controllers/OrderController.java
@@ -24,6 +24,7 @@ public class OrderController implements OrderAPI {
 
     @Override
     public ResponseEntity<?> createOrder(CreateOrderInput body) {
+        // TODO: In the future, send body to a topic in Kafka and return 201 to the client, receive in kafka and process the order in async
         final var aCommand = body.toCommand();
 
         final var aResult = this.createOrderUseCase.execute(aCommand);

--- a/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderCouponGatewayImpl.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/infrastructure/order/OrderCouponGatewayImpl.java
@@ -17,9 +17,8 @@ public class OrderCouponGatewayImpl implements OrderCouponGateway {
     }
 
     @Override
-    public OrderCouponApplyOutput applyCoupon(String couponCode) {
-        // TODO - Implement this method to receive total amount from order to validate coupon and apply it
-        final var aCommand = ApplyCouponCommand.with(couponCode, 100f);
+    public OrderCouponApplyOutput applyCoupon(final String couponCode, final float totalAmount) {
+        final var aCommand = ApplyCouponCommand.with(couponCode, totalAmount);
         final var aOutput = this.applyCouponUseCase.execute(aCommand);
         return new OrderCouponApplyOutput(
                 aOutput.couponId(),

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderCouponGatewayImplTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderCouponGatewayImplTest.java
@@ -24,13 +24,14 @@ public class OrderCouponGatewayImplTest {
     @Test
     void givenAValidCouponCode_whenCallApplyCoupon_thenCouponIsApplied() {
         final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+        final var aTotalAmount = 100f;
 
-        final var aCommand = ApplyCouponCommand.with(aCoupon.getCode().getValue(), 100f);
+        final var aCommand = ApplyCouponCommand.with(aCoupon.getCode().getValue(), aTotalAmount);
 
         Mockito.when(applyCouponUseCase.execute(aCommand))
                 .thenReturn(ApplyCouponOutput.from(aCoupon));
 
-        final var aOutput = this.orderCouponGatewayImpl.applyCoupon(aCoupon.getCode().getValue());
+        final var aOutput = this.orderCouponGatewayImpl.applyCoupon(aCoupon.getCode().getValue(), aTotalAmount);
 
         Assertions.assertEquals(aCoupon.getId().getValue(), aOutput.couponId());
         Assertions.assertEquals(aCoupon.getCode().getValue(), aOutput.couponCode());
@@ -40,13 +41,14 @@ public class OrderCouponGatewayImplTest {
     @Test
     void givenAValidCouponCode_whenCallApplyCouponButNoMoreSlot_thenThrowCouponNoMoreAvailableException() {
         final var aCoupon = Fixture.Coupons.limitedCouponActivated();
+        final var aTotalAmount = 100f;
         
-        final var aCommand = ApplyCouponCommand.with(aCoupon.getCode().getValue(), 100f);
+        final var aCommand = ApplyCouponCommand.with(aCoupon.getCode().getValue(), aTotalAmount);
 
         Mockito.when(applyCouponUseCase.execute(aCommand))
                 .thenThrow(new CouponNoMoreAvailableException());
 
         Assertions.assertThrows(CouponNoMoreAvailableException.class, () ->
-                this.orderCouponGatewayImpl.applyCoupon(aCoupon.getCode().getValue()));
+                this.orderCouponGatewayImpl.applyCoupon(aCoupon.getCode().getValue(), aTotalAmount));
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderMySQLGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/infrastructure/order/OrderMySQLGatewayTest.java
@@ -55,8 +55,6 @@ public class OrderMySQLGatewayTest {
         final var aOrder = Order.newOrder(
                 OrderCode.create(1L),
                 aCustomerId,
-                aCouponCode,
-                aCouponPercentage,
                 aOrderDelivery,
                 aOrderPayment.getId()
         );
@@ -68,6 +66,7 @@ public class OrderMySQLGatewayTest {
                 BigDecimal.valueOf(10.0)
         ));
         aOrder.calculateTotalAmount(aOrderDelivery);
+        aOrder.applyCoupon(aCouponCode, aCouponPercentage);
 
         Assertions.assertEquals(0, this.orderJpaEntityRepository.count());
         Assertions.assertEquals(0, this.orderDeliveryJpaEntityRepository.count());


### PR DESCRIPTION
## Descrição

O usecase de create order foi refatorado para chamar o método apply coupon e chamar o usecase de apply coupon com o total da order

## Mudanças Propostas

O usecase de create order foi refatorado para chamar o método apply coupon e chamar o usecase de apply coupon com o total da order

## Testes Realizados

Testes de unidade e integração

## Cobertura de Testes

O mínimo é 95%, está em 100%

## Problemas Conhecidos

N/A

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
